### PR TITLE
Match mobile pill dimensions

### DIFF
--- a/_assets/scss/posts.scss
+++ b/_assets/scss/posts.scss
@@ -499,6 +499,29 @@ time a {
   }
 }
 
+@media (max-width: 600px) {
+  .meta-pill {
+    min-height: 36px;
+    border-radius: 18px;
+    font-size: 0.95em;
+
+    .meta-segment {
+      padding: 0 16px;
+      line-height: 34px;
+    }
+  }
+
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 36px;
+    border-radius: 18px;
+    padding: 0 16px;
+    font-size: 0.95em;
+  }
+}
+
 /* Webmentions styles */
 .webmentions {
   margin-top: 3em;


### PR DESCRIPTION
## Summary
- update the mobile breakpoint styling for `.meta-pill` and `.pill` to mirror iOS Liquid Glass pill proportions

## Testing
- npm run dev

## Screenshots
![Updated mobile pill](browser:/invocations/qxwazpcr/artifacts/artifacts/mobile-pills.png)

------
https://chatgpt.com/codex/tasks/task_e_68db1cd9b774832583bb5f62ca4141e4