### PR TITLE
fix: pull content from submodule during Cloudflare Pages build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
+		"prebuild": "git submodule update --init --recursive || true",
 		"build": "vite build",
 		"preview": "bun run build && wrangler pages dev .svelte-kit/cloudflare",
 		"preview:remote": "bun run build && wrangler pages dev .svelte-kit/cloudflare --remote",

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -16,7 +16,7 @@ export interface Post {
 }
 
 export async function getAllPosts(): Promise<Post[]> {
-	const contentDir = join(process.cwd(), 'src/content');
+	const contentDir = join(process.cwd(), 'content');
 	const postTypes = ['notes', 'articles', 'bookmarks', 'photos', 'videos', 'replies', 'media'];
 	const posts: Post[] = [];
 


### PR DESCRIPTION
- Add prebuild script to initialize git submodule before vite build
- Update posts.ts to read from content/ submodule directory instead of src/content/

The site wasn't pulling new content because Cloudflare Pages doesn't
automatically initialize git submodules. The prebuild npm hook ensures
the content submodule is initialized before the build runs.