### PR TITLE
feat: add date-based permalinks for individual posts

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -82,3 +82,11 @@ export function getPostsByDay(posts: Post[]): Map<string, Post[]> {
 
 	return byDay;
 }
+
+export function getPostPermalink(post: Post): string {
+	const date = new Date(post.date);
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const day = String(date.getDate()).padStart(2, '0');
+	return `/${year}/${month}/${day}/${post.slug}/`;
+}

--- a/src/routes/[year]/+page.svelte
+++ b/src/routes/[year]/+page.svelte
@@ -24,6 +24,14 @@
 		if (text.length <= length) return text;
 		return text.slice(0, length).trim() + '...';
 	}
+
+	function getPermalink(post: { date: string; slug: string }) {
+		const date = new Date(post.date);
+		const year = date.getFullYear();
+		const month = String(date.getMonth() + 1).padStart(2, '0');
+		const day = String(date.getDate()).padStart(2, '0');
+		return `/${year}/${month}/${day}/${post.slug}/`;
+	}
 </script>
 
 <svelte:head>
@@ -57,7 +65,9 @@
 				<article class="h-entry post">
 					<div class="post-meta">
 						<span class="post-type">{post.type}</span>
-						<time class="dt-published" datetime={post.date}>{formatPostDate(post.date)}</time>
+						<a href={getPermalink(post)} class="u-url permalink">
+							<time class="dt-published" datetime={post.date}>{formatPostDate(post.date)}</time>
+						</a>
 					</div>
 
 					{#if post.title}
@@ -176,6 +186,15 @@
 		text-transform: uppercase;
 		font-weight: bold;
 		color: rgb(73, 73, 255);
+	}
+
+	.permalink {
+		color: inherit;
+		text-decoration: none;
+	}
+
+	.permalink:hover {
+		text-decoration: underline;
 	}
 
 	.post-title {

--- a/src/routes/[year]/[month]/+page.svelte
+++ b/src/routes/[year]/[month]/+page.svelte
@@ -25,6 +25,14 @@
 		return text.slice(0, length).trim() + '...';
 	}
 
+	function getPermalink(post: { date: string; slug: string }) {
+		const date = new Date(post.date);
+		const year = date.getFullYear();
+		const month = String(date.getMonth() + 1).padStart(2, '0');
+		const day = String(date.getDate()).padStart(2, '0');
+		return `/${year}/${month}/${day}/${post.slug}/`;
+	}
+
 	const monthName = new Date(`${data.year}-${data.month}-01`).toLocaleString('en-US', {
 		month: 'long'
 	});
@@ -61,7 +69,9 @@
 				<article class="h-entry post">
 					<div class="post-meta">
 						<span class="post-type">{post.type}</span>
-						<time class="dt-published" datetime={post.date}>{formatPostDate(post.date)}</time>
+						<a href={getPermalink(post)} class="u-url permalink">
+							<time class="dt-published" datetime={post.date}>{formatPostDate(post.date)}</time>
+						</a>
 					</div>
 
 					{#if post.title}
@@ -181,6 +191,15 @@
 		text-transform: uppercase;
 		font-weight: bold;
 		color: rgb(73, 73, 255);
+	}
+
+	.permalink {
+		color: inherit;
+		text-decoration: none;
+	}
+
+	.permalink:hover {
+		text-decoration: underline;
 	}
 
 	.post-title {

--- a/src/routes/[year]/[month]/[day]/+page.svelte
+++ b/src/routes/[year]/[month]/[day]/+page.svelte
@@ -20,6 +20,14 @@
 		return text.slice(0, length).trim() + '...';
 	}
 
+	function getPermalink(post: { date: string; slug: string }) {
+		const date = new Date(post.date);
+		const year = date.getFullYear();
+		const month = String(date.getMonth() + 1).padStart(2, '0');
+		const day = String(date.getDate()).padStart(2, '0');
+		return `/${year}/${month}/${day}/${post.slug}/`;
+	}
+
 	const fullDate = new Date(`${data.year}-${data.month}-${data.day}`).toLocaleString('en-US', {
 		month: 'long',
 		day: 'numeric',
@@ -46,7 +54,9 @@
 			<article class="h-entry post">
 				<div class="post-meta">
 					<span class="post-type">{post.type}</span>
-					<time class="dt-published" datetime={post.date}>{formatPostDate(post.date)}</time>
+					<a href={getPermalink(post)} class="u-url permalink">
+						<time class="dt-published" datetime={post.date}>{formatPostDate(post.date)}</time>
+					</a>
 				</div>
 
 				{#if post.title}
@@ -132,6 +142,15 @@
 		text-transform: uppercase;
 		font-weight: bold;
 		color: rgb(73, 73, 255);
+	}
+
+	.permalink {
+		color: inherit;
+		text-decoration: none;
+	}
+
+	.permalink:hover {
+		text-decoration: underline;
 	}
 
 	.post-title {

--- a/src/routes/[year]/[month]/[day]/[slug]/+page.server.ts
+++ b/src/routes/[year]/[month]/[day]/[slug]/+page.server.ts
@@ -1,0 +1,29 @@
+import type { PageServerLoad } from './$types';
+import { getAllPosts } from '$lib/posts';
+import { error } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async ({ params }) => {
+	const { year, month, day, slug } = params;
+
+	// Validate year, month, and day format
+	if (!/^\d{4}$/.test(year) || !/^\d{2}$/.test(month) || !/^\d{2}$/.test(day)) {
+		throw error(404, 'Not found');
+	}
+
+	const dateKey = `${year}-${month}-${day}`;
+	const allPosts = await getAllPosts();
+
+	// Find post matching the date and slug
+	const post = allPosts.find(p => p.date.startsWith(dateKey) && p.slug === slug);
+
+	if (!post) {
+		throw error(404, 'Post not found');
+	}
+
+	return {
+		year,
+		month,
+		day,
+		post
+	};
+};

--- a/src/routes/[year]/[month]/[day]/[slug]/+page.svelte
+++ b/src/routes/[year]/[month]/[day]/[slug]/+page.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import Nav from '$lib/components/Nav.svelte';
+
+	let { data }: { data: PageData } = $props();
+
+	function formatPostDate(dateStr: string) {
+		const date = new Date(dateStr);
+		return date.toLocaleString('en-US', {
+			month: 'short',
+			day: 'numeric',
+			year: 'numeric',
+			hour: 'numeric',
+			minute: '2-digit'
+		});
+	}
+
+	const permalink = `/${data.year}/${data.month}/${data.day}/${data.post.slug}/`;
+</script>
+
+<svelte:head>
+	<title>{data.post.title || data.post.type} - Casey Gollan</title>
+	<meta name="description" content={data.post.summary || data.post.content.slice(0, 160)} />
+	<link rel="canonical" href="https://caseyagollan.com{permalink}" />
+	<link rel="stylesheet" href="https://use.typekit.net/rfh8wvj.css" />
+</svelte:head>
+
+<Nav currentPage="posts" showPostsLink={true} />
+
+<div class="container">
+	<article class="h-entry post">
+		<div class="post-meta">
+			<span class="post-type">{data.post.type}</span>
+			<a href={permalink} class="u-url permalink">
+				<time class="dt-published" datetime={data.post.date}>{formatPostDate(data.post.date)}</time>
+			</a>
+		</div>
+
+		{#if data.post.title}
+			<h1 class="p-name post-title">{data.post.title}</h1>
+		{/if}
+
+		<div class="e-content post-content">
+			{@html data.post.content}
+		</div>
+
+		{#if data.post.category}
+			<div class="post-categories">
+				{#if typeof data.post.category === 'string'}
+					<span class="category-tag p-category">{data.post.category}</span>
+				{:else if Array.isArray(data.post.category)}
+					{#each data.post.category as cat (cat)}
+						<span class="category-tag p-category">{cat}</span>
+					{/each}
+				{/if}
+			</div>
+		{/if}
+	</article>
+</div>
+
+<style>
+	:global(body) {
+		background: gray;
+		color: white;
+		font-family: ff-dagny-web-pro, sans-serif;
+		margin: 0;
+		padding: 0;
+	}
+
+	.container {
+		max-width: 800px;
+		margin: 0 auto;
+		padding: 2rem;
+	}
+
+	.post {
+		margin-bottom: 2rem;
+	}
+
+	.post-meta {
+		display: flex;
+		gap: 1rem;
+		font-size: 0.9rem;
+		opacity: 0.8;
+		margin-bottom: 0.5rem;
+	}
+
+	.post-type {
+		text-transform: uppercase;
+		font-weight: bold;
+		color: rgb(73, 73, 255);
+	}
+
+	.permalink {
+		color: inherit;
+		text-decoration: none;
+	}
+
+	.permalink:hover {
+		text-decoration: underline;
+	}
+
+	.post-title {
+		font-size: 2rem;
+		margin: 0.5rem 0 1rem;
+		font-weight: bold;
+	}
+
+	.post-content {
+		margin: 1rem 0;
+		line-height: 1.6;
+	}
+
+	.post-content :global(p) {
+		margin: 1rem 0;
+	}
+
+	.post-content :global(a) {
+		color: rgb(150, 150, 255);
+	}
+
+	.post-content :global(blockquote) {
+		border-left: 3px solid rgba(255, 255, 255, 0.3);
+		margin-left: 0;
+		padding-left: 1rem;
+		font-style: italic;
+	}
+
+	.post-categories {
+		display: flex;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+		margin-top: 2rem;
+	}
+
+	.category-tag {
+		background: rgba(255, 255, 255, 0.1);
+		padding: 0.25rem 0.75rem;
+		border-radius: 3px;
+		font-size: 0.85rem;
+	}
+</style>

--- a/src/routes/posts/+page.svelte
+++ b/src/routes/posts/+page.svelte
@@ -24,6 +24,14 @@
 		if (text.length <= length) return text;
 		return text.slice(0, length).trim() + '...';
 	}
+
+	function getPermalink(post: { date: string; slug: string }) {
+		const date = new Date(post.date);
+		const year = date.getFullYear();
+		const month = String(date.getMonth() + 1).padStart(2, '0');
+		const day = String(date.getDate()).padStart(2, '0');
+		return `/${year}/${month}/${day}/${post.slug}/`;
+	}
 </script>
 
 <svelte:head>
@@ -59,7 +67,9 @@
 				<article class="h-entry post">
 					<div class="post-meta">
 						<span class="post-type">{post.type}</span>
-						<time class="dt-published" datetime={post.date}>{formatPostDate(post.date)}</time>
+						<a href={getPermalink(post)} class="u-url permalink">
+							<time class="dt-published" datetime={post.date}>{formatPostDate(post.date)}</time>
+						</a>
 					</div>
 
 					{#if post.title}
@@ -178,6 +188,15 @@
 		text-transform: uppercase;
 		font-weight: bold;
 		color: rgb(73, 73, 255);
+	}
+
+	.permalink {
+		color: inherit;
+		text-decoration: none;
+	}
+
+	.permalink:hover {
+		text-decoration: underline;
 	}
 
 	.post-title {


### PR DESCRIPTION
- Create individual post route at /[year]/[month]/[day]/[slug]/
- Make post dates clickable links to permalinks on all listing pages
- Add getPostPermalink utility function to posts.ts
- Apply permalink styling across posts, year, month, and day archives