### PR TITLE
feat: improve posts UI with icons, button styling, and component refactoring

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,8 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link rel="preconnect" href="https://use.typekit.net" crossorigin="anonymous" />
+		<link rel="stylesheet" href="https://use.typekit.net/rfh8wvj.css" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/lib/components/WebmentionCounts.svelte
+++ b/src/lib/components/WebmentionCounts.svelte
@@ -50,17 +50,23 @@
 <style>
 	.webmention-counts {
 		display: inline-flex;
-		gap: 0.5em;
+		gap: 0.375rem;
 		text-decoration: none;
 		color: inherit;
-		font-size: 0.9em;
+		font-size: 0.75rem;
+		padding: 0.25rem 0.5rem;
+		border-radius: 4px;
+		transition: background 0.15s ease, color 0.15s ease;
+		opacity: 0.7;
 	}
 
 	.webmention-counts:hover {
-		text-decoration: underline;
+		background: rgba(255, 255, 255, 0.15);
+		color: #fff;
+		opacity: 1;
 	}
 
 	.wm-count {
-		opacity: 0.8;
+		opacity: 0.9;
 	}
 </style>

--- a/src/lib/components/posts/ArchiveHeader.svelte
+++ b/src/lib/components/posts/ArchiveHeader.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	interface Props {
+		title: string;
+		count: number;
+		backLink?: string;
+		backText?: string;
+	}
+
+	let { title, count, backLink = '/posts/', backText = 'All Posts' }: Props = $props();
+</script>
+
+<div class="header">
+	{#if backLink}
+		<a href={backLink} class="back-link">{backText}</a>
+	{/if}
+	<h1 class="page-title">{title} <span class="count">({count})</span></h1>
+</div>
+
+<style>
+	.header {
+		margin-bottom: 3rem;
+	}
+
+	.back-link {
+		color: rgba(255, 255, 255, 0.7);
+		text-decoration: none;
+		font-size: 0.875rem;
+		display: inline-block;
+		margin-bottom: 0.5rem;
+	}
+
+	.back-link:hover {
+		color: #fff;
+	}
+
+	.back-link::before {
+		content: '← ';
+	}
+
+	.page-title {
+		font-size: 1.5rem;
+		font-weight: 500;
+		margin: 0;
+	}
+
+	.count {
+		font-weight: 400;
+		color: rgba(255, 255, 255, 0.7);
+	}
+</style>

--- a/src/lib/components/posts/DateArchiveHeader.svelte
+++ b/src/lib/components/posts/DateArchiveHeader.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	interface Props {
+		year: string;
+		month?: string;
+		day?: string;
+		count?: number;
+	}
+
+	let { year, month, day, count }: Props = $props();
+
+	const backLink = $derived.by(() => {
+		if (day && month) {
+			return `/${year}/${month}/`;
+		} else if (month) {
+			return `/${year}/`;
+		}
+		return '/posts/';
+	});
+
+	const backText = $derived.by(() => {
+		if (day && month) {
+			const date = new Date(`${year}-${month}-01`);
+			return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+		} else if (month) {
+			return year;
+		}
+		return 'All Posts';
+	});
+
+	const countDescription = $derived.by(() => {
+		if (count === undefined) return '';
+		const postWord = count === 1 ? 'post' : 'posts';
+
+		if (day && month) {
+			const date = new Date(`${year}-${month}-${day}`);
+			const formatted = date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+			return `${count} ${postWord} from ${formatted}`;
+		} else if (month) {
+			const date = new Date(`${year}-${month}-01`);
+			const formatted = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+			return `${count} ${postWord} from ${formatted}`;
+		}
+		return `${count} ${postWord} from ${year}`;
+	});
+</script>
+
+<div class="header">
+	<a href={backLink} class="back-link">{backText}</a>
+
+	<div class="date-nav">
+		<a href="/{year}/" class="date-segment" class:active={!month}>{year}</a>
+		{#if month}
+			<a href="/{year}/{month}/" class="date-segment" class:active={month && !day}>{month}</a>
+		{/if}
+		{#if day}
+			<a href="/{year}/{month}/{day}/" class="date-segment" class:active={!!day}>{day}</a>
+		{/if}
+	</div>
+
+	{#if count !== undefined}
+		<p class="count-description">{countDescription}</p>
+	{/if}
+</div>
+
+<style>
+	.header {
+		margin-bottom: 3rem;
+	}
+
+	.back-link {
+		color: rgba(255, 255, 255, 0.7);
+		text-decoration: none;
+		font-size: 0.875rem;
+		display: inline-block;
+		margin-bottom: 0.5rem;
+		margin-left: -0.5rem;
+		padding: 0.25rem 0.5rem;
+		border-radius: 4px;
+		transition: background 0.15s ease, color 0.15s ease;
+	}
+
+	.back-link:hover {
+		background: rgba(255, 255, 255, 0.15);
+		color: #fff;
+	}
+
+	.back-link::before {
+		content: '← ';
+	}
+
+	.date-nav {
+		display: inline-flex;
+		background: #0000ff;
+		border-radius: 4px;
+		overflow: hidden;
+	}
+
+	.date-segment {
+		padding: 0.5rem 1rem;
+		color: #fff;
+		text-decoration: none;
+		font-size: 1.25rem;
+		font-weight: 500;
+		font-variant-numeric: tabular-nums;
+		transition: background 0.15s ease;
+		border-right: 1px solid rgba(255, 255, 255, 0.3);
+	}
+
+	.date-segment:last-child {
+		border-right: none;
+	}
+
+	.date-segment:hover {
+		background: #4949ff;
+	}
+
+	.date-segment.active {
+		background: #4949ff;
+	}
+
+	.count-description {
+		margin: 0.75rem 0 0;
+		font-size: 0.875rem;
+		color: rgba(255, 255, 255, 0.7);
+	}
+</style>

--- a/src/lib/components/posts/DateArchiveHeader.svelte
+++ b/src/lib/components/posts/DateArchiveHeader.svelte
@@ -26,40 +26,20 @@
 		}
 		return 'All Posts';
 	});
-
-	const countDescription = $derived.by(() => {
-		if (count === undefined) return '';
-		const postWord = count === 1 ? 'post' : 'posts';
-
-		if (day && month) {
-			const date = new Date(`${year}-${month}-${day}`);
-			const formatted = date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
-			return `${count} ${postWord} from ${formatted}`;
-		} else if (month) {
-			const date = new Date(`${year}-${month}-01`);
-			const formatted = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
-			return `${count} ${postWord} from ${formatted}`;
-		}
-		return `${count} ${postWord} from ${year}`;
-	});
 </script>
 
 <div class="header">
 	<a href={backLink} class="back-link">{backText}</a>
 
 	<div class="date-nav">
-		<a href="/{year}/" class="date-segment" class:active={!month}>{year}</a>
+		<a href="/{year}/" class="date-segment" class:active={!month}>{year}{#if !month && count !== undefined}<span class="segment-count">{count}</span>{/if}</a>
 		{#if month}
-			<a href="/{year}/{month}/" class="date-segment" class:active={month && !day}>{month}</a>
+			<a href="/{year}/{month}/" class="date-segment" class:active={month && !day}>{month}{#if month && !day && count !== undefined}<span class="segment-count">{count}</span>{/if}</a>
 		{/if}
 		{#if day}
-			<a href="/{year}/{month}/{day}/" class="date-segment" class:active={!!day}>{day}</a>
+			<a href="/{year}/{month}/{day}/" class="date-segment" class:active={!!day}>{day}{#if day && count !== undefined}<span class="segment-count">{count}</span>{/if}</a>
 		{/if}
 	</div>
-
-	{#if count !== undefined}
-		<p class="count-description">{countDescription}</p>
-	{/if}
 </div>
 
 <style>
@@ -71,10 +51,11 @@
 		color: rgba(255, 255, 255, 0.7);
 		text-decoration: none;
 		font-size: 0.875rem;
-		display: inline-block;
+		display: block;
 		margin-bottom: 0.5rem;
-		margin-left: -0.5rem;
 		padding: 0.25rem 0.5rem;
+		margin-left: -0.5rem;
+		width: fit-content;
 		border-radius: 4px;
 		transition: background 0.15s ease, color 0.15s ease;
 	}
@@ -118,9 +99,13 @@
 		background: #4949ff;
 	}
 
-	.count-description {
-		margin: 0.75rem 0 0;
-		font-size: 0.875rem;
-		color: rgba(255, 255, 255, 0.7);
+	.segment-count {
+		background: rgba(255, 255, 255, 0.2);
+		color: rgba(255, 255, 255, 0.9);
+		font-size: 0.75rem;
+		padding: 0.125rem 0.5rem;
+		border-radius: 10px;
+		margin-left: 0.5rem;
+		font-variant-numeric: tabular-nums;
 	}
 </style>

--- a/src/lib/components/posts/DateHeader.svelte
+++ b/src/lib/components/posts/DateHeader.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	interface Props {
+		dateKey: string;
+	}
+
+	let { dateKey }: Props = $props();
+
+	function formatDate(dateStr: string) {
+		const [year, month, day] = dateStr.split('-');
+		return { year, month, day };
+	}
+
+	const dateInfo = $derived(formatDate(dateKey));
+</script>
+
+<h2 class="date-header">
+	<div class="meta-pill">
+		<a href="/{dateInfo.year}/" class="meta-segment">{dateInfo.year}</a>
+		<a href="/{dateInfo.year}/{dateInfo.month}/" class="meta-segment">{dateInfo.month}</a>
+		<a href="/{dateInfo.year}/{dateInfo.month}/{dateInfo.day}/" class="meta-segment">{dateInfo.day}</a>
+	</div>
+</h2>
+
+<style>
+	.date-header {
+		margin: 1.25rem 0 0.75rem;
+		font-size: 0.875rem;
+		font-weight: 400;
+		position: sticky;
+		top: 0;
+		background: #808080;
+		padding: 0.375rem 0;
+		z-index: 10;
+	}
+
+	.date-header:first-child {
+		margin-top: 0;
+	}
+
+	.meta-pill {
+		display: inline-flex;
+		background: #0000ff;
+		border-radius: 4px;
+		overflow: hidden;
+	}
+
+	.meta-segment {
+		padding: 0.25rem 0.5rem;
+		color: #fff;
+		text-decoration: none;
+		border-right: 1px solid rgba(255, 255, 255, 0.3);
+		font-size: 0.75rem;
+		font-weight: 500;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.meta-segment:last-child {
+		border-right: none;
+	}
+
+	.meta-segment:hover {
+		background: #4949ff;
+	}
+</style>

--- a/src/lib/components/posts/DropdownArchiveHeader.svelte
+++ b/src/lib/components/posts/DropdownArchiveHeader.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+	interface Option {
+		value: string;
+		label: string;
+		href: string;
+		count?: number;
+		icon?: string;
+	}
+
+	interface Props {
+		current: string;
+		currentIcon?: string;
+		options: Option[];
+		countDescription?: string;
+		backLink?: string;
+		backText?: string;
+	}
+
+	let { current, currentIcon, options, countDescription, backLink = '/posts/', backText = 'All Posts' }: Props = $props();
+
+	let isOpen = $state(false);
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			isOpen = false;
+		}
+	}
+
+	function handleClickOutside(event: MouseEvent) {
+		const target = event.target as HTMLElement;
+		if (!target.closest('.dropdown-container')) {
+			isOpen = false;
+		}
+	}
+</script>
+
+<svelte:window onkeydown={handleKeydown} onclick={handleClickOutside} />
+
+<div class="header">
+	<a href={backLink} class="back-link">{backText}</a>
+
+	<div class="dropdown-container">
+		<button
+			class="dropdown-trigger"
+			onclick={() => isOpen = !isOpen}
+			aria-expanded={isOpen}
+			aria-haspopup="listbox"
+		>
+			<span class="current-value">{#if currentIcon}<span class="current-icon">{currentIcon}</span>{/if}{current}</span>
+			<span class="dropdown-arrow" class:open={isOpen}>▾</span>
+		</button>
+
+		{#if isOpen}
+			<div class="dropdown-menu" role="listbox">
+				{#each options as option (option.value)}
+					<a
+						href={option.href}
+						class="dropdown-item"
+						class:active={option.label === current}
+						role="option"
+						aria-selected={option.label === current}
+					>
+						<span class="option-label">{#if option.icon}<span class="option-icon">{option.icon}</span>{/if}{option.label}</span>
+						{#if option.count !== undefined}
+							<span class="option-count">{option.count}</span>
+						{/if}
+					</a>
+				{/each}
+			</div>
+		{/if}
+	</div>
+
+	{#if countDescription}
+		<p class="count-description">{countDescription}</p>
+	{/if}
+</div>
+
+<style>
+	.header {
+		margin-bottom: 3rem;
+	}
+
+	.back-link {
+		color: rgba(255, 255, 255, 0.7);
+		text-decoration: none;
+		font-size: 0.875rem;
+		display: inline-block;
+		margin-bottom: 0.5rem;
+		margin-left: -0.5rem;
+		padding: 0.25rem 0.5rem;
+		border-radius: 4px;
+		transition: background 0.15s ease, color 0.15s ease;
+	}
+
+	.back-link:hover {
+		background: rgba(255, 255, 255, 0.15);
+		color: #fff;
+	}
+
+	.back-link::before {
+		content: '← ';
+	}
+
+	.dropdown-container {
+		position: relative;
+	}
+
+	.dropdown-trigger {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		background: #0000ff;
+		border: none;
+		border-radius: 4px;
+		padding: 0.5rem 1rem;
+		color: #fff;
+		font-size: 1.25rem;
+		font-weight: 500;
+		font-family: inherit;
+		cursor: pointer;
+		transition: background 0.15s ease;
+	}
+
+	.dropdown-trigger:hover {
+		background: #4949ff;
+	}
+
+	.dropdown-arrow {
+		font-size: 0.875rem;
+		transition: transform 0.15s ease;
+	}
+
+	.dropdown-arrow.open {
+		transform: rotate(180deg);
+	}
+
+	.dropdown-menu {
+		position: absolute;
+		top: calc(100% + 0.25rem);
+		left: 0;
+		min-width: 180px;
+		max-height: 300px;
+		overflow-y: auto;
+		background: #0000ff;
+		border-radius: 4px;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+		z-index: 100;
+	}
+
+	.dropdown-item {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0.5rem 1rem;
+		color: #fff;
+		text-decoration: none;
+		font-size: 1rem;
+		transition: background 0.15s ease;
+	}
+
+	.dropdown-item:hover {
+		background: #4949ff;
+	}
+
+	.dropdown-item.active {
+		background: #4949ff;
+	}
+
+	.current-icon,
+	.option-icon {
+		margin-right: 0.5rem;
+	}
+
+	.option-count {
+		background: rgba(255, 255, 255, 0.2);
+		color: rgba(255, 255, 255, 0.9);
+		font-size: 0.75rem;
+		padding: 0.125rem 0.5rem;
+		border-radius: 10px;
+		margin-left: 0.5rem;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.count-description {
+		margin: 0.75rem 0 0;
+		font-size: 0.875rem;
+		color: rgba(255, 255, 255, 0.7);
+	}
+</style>

--- a/src/lib/components/posts/DropdownArchiveHeader.svelte
+++ b/src/lib/components/posts/DropdownArchiveHeader.svelte
@@ -11,12 +11,13 @@
 		current: string;
 		currentIcon?: string;
 		options: Option[];
+		count?: number;
 		countDescription?: string;
 		backLink?: string;
 		backText?: string;
 	}
 
-	let { current, currentIcon, options, countDescription, backLink = '/posts/', backText = 'All Posts' }: Props = $props();
+	let { current, currentIcon, options, count, countDescription, backLink = '/posts/', backText = 'All Posts' }: Props = $props();
 
 	let isOpen = $state(false);
 
@@ -47,6 +48,9 @@
 			aria-haspopup="listbox"
 		>
 			<span class="current-value">{#if currentIcon}<span class="current-icon">{currentIcon}</span>{/if}{current}</span>
+			{#if count !== undefined}
+				<span class="header-count">{count}</span>
+			{/if}
 			<span class="dropdown-arrow" class:open={isOpen}>▾</span>
 		</button>
 
@@ -103,6 +107,15 @@
 
 	.dropdown-container {
 		position: relative;
+	}
+
+	.header-count {
+		background: rgba(255, 255, 255, 0.2);
+		color: rgba(255, 255, 255, 0.9);
+		font-size: 0.75rem;
+		padding: 0.125rem 0.5rem;
+		border-radius: 10px;
+		font-variant-numeric: tabular-nums;
 	}
 
 	.dropdown-trigger {

--- a/src/lib/components/posts/PostCard.svelte
+++ b/src/lib/components/posts/PostCard.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import PostMeta from './PostMeta.svelte';
 	import PostContent from './PostContent.svelte';
-	import PostCategories from './PostCategories.svelte';
 	import type { Post } from '$lib/posts-types';
 
 	interface Props {
@@ -50,6 +49,8 @@
 		{permalink}
 		syndication={post.syndication}
 		{showType}
+		category={post.category}
+		{activeTag}
 	/>
 
 	{#if post.title}
@@ -70,8 +71,6 @@
 	{:else}
 		<PostContent content={post.content} />
 	{/if}
-
-	<PostCategories category={post.category} {activeTag} />
 </article>
 
 <style>
@@ -113,12 +112,16 @@
 	.read-more {
 		display: inline-block;
 		margin-top: 0.5rem;
-		color: #4949ff;
+		color: rgba(255, 255, 255, 0.6);
 		text-decoration: none;
-		font-size: 0.8125rem;
+		font-size: 0.75rem;
+		padding: 0.25rem 0.5rem;
+		border-radius: 4px;
+		transition: background 0.15s ease, color 0.15s ease;
 	}
 
 	.read-more:hover {
-		text-decoration: underline;
+		background: rgba(255, 255, 255, 0.15);
+		color: #fff;
 	}
 </style>

--- a/src/lib/components/posts/PostCard.svelte
+++ b/src/lib/components/posts/PostCard.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+	import PostMeta from './PostMeta.svelte';
+	import PostContent from './PostContent.svelte';
+	import PostCategories from './PostCategories.svelte';
+	import type { Post } from '$lib/posts-types';
+
+	interface Props {
+		post: Post;
+		showType?: boolean;
+		activeTag?: string;
+	}
+
+	let { post, showType = true, activeTag }: Props = $props();
+
+	function getPermalink(p: { date: string; slug: string }) {
+		const date = new Date(p.date);
+		const year = date.getFullYear();
+		const month = String(date.getMonth() + 1).padStart(2, '0');
+		const day = String(date.getDate()).padStart(2, '0');
+		return `/${year}/${month}/${day}/${p.slug}/`;
+	}
+
+	function getPreview(content: string, maxLength: number = 280): string {
+		// Strip HTML tags
+		let stripped = content.replace(/<[^>]*>/g, '');
+		// Strip markdown links [text](url) -> text
+		stripped = stripped.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+		// Strip markdown emphasis *text* or _text_ or **text** or __text__
+		stripped = stripped.replace(/(\*\*|__)(.*?)\1/g, '$2');
+		stripped = stripped.replace(/(\*|_)(.*?)\1/g, '$2');
+		// Strip markdown code `code`
+		stripped = stripped.replace(/`([^`]+)`/g, '$1');
+		// Normalize whitespace
+		stripped = stripped.replace(/\s+/g, ' ').trim();
+		if (stripped.length <= maxLength) return stripped;
+		return stripped.slice(0, maxLength).trim() + '...';
+	}
+
+	const permalink = $derived(getPermalink(post));
+	const isArticle = $derived(post.type === 'article');
+</script>
+
+<article class="h-entry post">
+	<!-- Hidden h-card for author info - required by Bridgy and other IndieWeb tools -->
+	<a href="https://caseyagollan.com" class="p-author h-card" hidden>Casey Gollan</a>
+
+	<PostMeta
+		type={post.type}
+		date={post.date}
+		{permalink}
+		syndication={post.syndication}
+		{showType}
+	/>
+
+	{#if post.title}
+		<h3 class="p-name post-title">
+			{#if isArticle}
+				<a href={permalink} class="title-link">{post.title}</a>
+			{:else}
+				{post.title}
+			{/if}
+		</h3>
+	{/if}
+
+	{#if isArticle}
+		<p class="p-summary preview">
+			{post.summary || getPreview(post.content)}
+		</p>
+		<a href={permalink} class="read-more">Read more</a>
+	{:else}
+		<PostContent content={post.content} />
+	{/if}
+
+	<PostCategories category={post.category} {activeTag} />
+</article>
+
+<style>
+	.post {
+		margin-bottom: 1.5rem;
+		padding-bottom: 1.5rem;
+		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+	}
+
+	.post:last-child {
+		border-bottom: none;
+		margin-bottom: 0;
+		padding-bottom: 0;
+	}
+
+	.post-title {
+		font-size: 1.25rem;
+		line-height: 1.3;
+		margin: 0.25rem 0 0.5rem;
+		font-weight: 600;
+	}
+
+	.title-link {
+		color: inherit;
+		text-decoration: none;
+	}
+
+	.title-link:hover {
+		text-decoration: underline;
+	}
+
+	.preview {
+		margin: 0;
+		line-height: 1.5;
+		color: rgba(255, 255, 255, 0.8);
+		font-size: 0.9375rem;
+	}
+
+	.read-more {
+		display: inline-block;
+		margin-top: 0.5rem;
+		color: #4949ff;
+		text-decoration: none;
+		font-size: 0.8125rem;
+	}
+
+	.read-more:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/src/lib/components/posts/PostCategories.svelte
+++ b/src/lib/components/posts/PostCategories.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	interface Props {
+		category: string | string[] | undefined;
+		activeTag?: string;
+	}
+
+	let { category, activeTag }: Props = $props();
+
+	function getCategories(cat: string | string[] | undefined): string[] {
+		if (!cat) return [];
+		return Array.isArray(cat) ? cat : [cat];
+	}
+
+	const categories = $derived(getCategories(category));
+</script>
+
+{#if categories.length > 0}
+	<div class="post-categories">
+		{#each categories as cat (cat)}
+			<a href="/tag/{cat.toLowerCase()}/" class="category-tag" class:active={cat.toLowerCase() === activeTag?.toLowerCase()}>{cat}</a>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.post-categories {
+		display: flex;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+		margin-top: 1rem;
+	}
+
+	.category-tag {
+		background: rgba(255, 255, 255, 0.1);
+		padding: 0.25rem 0.625rem;
+		border-radius: 3px;
+		font-size: 0.8125rem;
+		color: #fff;
+		text-decoration: none;
+		transition: background 0.15s ease;
+	}
+
+	.category-tag:hover {
+		background: rgba(255, 255, 255, 0.2);
+	}
+
+	.category-tag.active {
+		background: #0000ff;
+	}
+</style>

--- a/src/lib/components/posts/PostContent.svelte
+++ b/src/lib/components/posts/PostContent.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+	import { renderContentSync } from '$lib/utils/renderContent';
+
+	interface Props {
+		content: string;
+	}
+
+	let { content }: Props = $props();
+</script>
+
+<div class="e-content post-content">
+	{@html renderContentSync(content)}
+</div>
+
+<style>
+	.post-content {
+		margin: 0;
+		line-height: 1.65;
+	}
+
+	.post-content :global(p) {
+		margin: 0 0 1rem;
+	}
+
+	.post-content :global(p:last-child) {
+		margin-bottom: 0;
+	}
+
+	.post-content :global(a) {
+		color: #fff;
+		text-decoration: underline;
+		text-decoration-color: rgba(255, 255, 255, 0.4);
+		text-underline-offset: 0.15em;
+		transition: text-decoration-color 0.15s ease;
+	}
+
+	.post-content :global(a:hover) {
+		text-decoration-color: #fff;
+	}
+
+	.post-content :global(strong) {
+		font-weight: 600;
+	}
+
+	.post-content :global(em) {
+		font-style: italic;
+	}
+
+	.post-content :global(code) {
+		font-family: ui-monospace, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', monospace;
+		font-size: 0.9em;
+		background: rgba(255, 255, 255, 0.1);
+		padding: 0.1em 0.3em;
+		border-radius: 3px;
+	}
+
+	.post-content :global(pre) {
+		background: rgba(0, 0, 0, 0.3);
+		padding: 1rem;
+		border-radius: 4px;
+		overflow-x: auto;
+		margin: 1rem 0;
+	}
+
+	.post-content :global(pre code) {
+		background: none;
+		padding: 0;
+	}
+
+	.post-content :global(blockquote) {
+		margin: 1rem 0;
+		padding-left: 1rem;
+		border-left: 3px solid rgba(255, 255, 255, 0.3);
+		color: rgba(255, 255, 255, 0.85);
+		font-style: italic;
+	}
+
+	.post-content :global(ul),
+	.post-content :global(ol) {
+		margin: 1rem 0;
+		padding-left: 1.5rem;
+	}
+
+	.post-content :global(li) {
+		margin-bottom: 0.5rem;
+	}
+
+	.post-content :global(img) {
+		max-width: 100%;
+		height: auto;
+		border-radius: 4px;
+		margin: 1rem 0;
+	}
+
+	/* oEmbed video containers */
+	.post-content :global(.embed) {
+		margin: 1.5rem 0;
+	}
+
+	.post-content :global(.embed-video) {
+		position: relative;
+		padding-bottom: 56.25%;
+		height: 0;
+		overflow: hidden;
+		border-radius: 4px;
+		background: rgba(0, 0, 0, 0.2);
+	}
+
+	.post-content :global(.embed-video iframe) {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		border: 0;
+	}
+</style>

--- a/src/lib/components/posts/PostMeta.svelte
+++ b/src/lib/components/posts/PostMeta.svelte
@@ -9,9 +9,18 @@
 		permalink: string;
 		syndication?: string[];
 		showType?: boolean;
+		category?: string | string[];
+		activeTag?: string;
 	}
 
-	let { type, date, permalink, syndication = [], showType = true }: Props = $props();
+	let { type, date, permalink, syndication = [], showType = true, category, activeTag }: Props = $props();
+
+	function getCategories(cat: string | string[] | undefined): string[] {
+		if (!cat) return [];
+		return Array.isArray(cat) ? cat : [cat];
+	}
+
+	const categories = $derived(getCategories(category));
 
 	function getTypePlural(t: string): string {
 		return POST_TYPE_PLURALS[t] || t + 's';
@@ -53,6 +62,9 @@
 			<span class="permalink-icon">🔗</span>
 			<time class="dt-published" datetime={date}>{formatRelativeDate(date)}</time>
 		</a>
+		{#each categories as cat (cat)}
+			<a href="/tag/{cat.toLowerCase()}/" class="p-category category-tag" class:active={cat.toLowerCase() === activeTag?.toLowerCase()}>#{cat}</a>
+		{/each}
 	</div>
 	{#if (syndication && syndication.length > 0)}
 		<div class="meta-secondary">
@@ -97,7 +109,8 @@
 
 	.post-type,
 	.permalink,
-	.syndication-link {
+	.syndication-link,
+	.category-tag {
 		color: inherit;
 		text-decoration: none;
 		padding: 0.25rem 0.5rem;
@@ -107,8 +120,14 @@
 
 	.post-type:hover,
 	.permalink:hover,
-	.syndication-link:hover {
+	.syndication-link:hover,
+	.category-tag:hover {
 		background: rgba(255, 255, 255, 0.15);
+		color: #fff;
+	}
+
+	.category-tag.active {
+		background: rgba(255, 255, 255, 0.2);
 		color: #fff;
 	}
 

--- a/src/lib/components/posts/PostMeta.svelte
+++ b/src/lib/components/posts/PostMeta.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+	import WebmentionCounts from '$lib/components/WebmentionCounts.svelte';
+	import { POST_TYPE_PLURALS } from '$lib/posts-types';
+	import { formatRelativeDate, formatAbsoluteDate } from '$lib/utils/formatDate';
+
+	interface Props {
+		type: string;
+		date: string;
+		permalink: string;
+		syndication?: string[];
+		showType?: boolean;
+	}
+
+	let { type, date, permalink, syndication = [], showType = true }: Props = $props();
+
+	function getTypePlural(t: string): string {
+		return POST_TYPE_PLURALS[t] || t + 's';
+	}
+
+	const TYPE_ICONS: Record<string, string> = {
+		note: '📝',
+		article: '📄',
+		bookmark: '🔖',
+		photo: '📷',
+		video: '🎬',
+		reply: '💬',
+		media: '🎵'
+	};
+
+	function getTypeIcon(t: string): string {
+		return TYPE_ICONS[t] || '📌';
+	}
+
+	function getSyndicationInfo(link: string): { icon: string; title: string } {
+		if (link.includes('social.coop') || link.includes('mastodon')) {
+			return { icon: '🐘', title: 'View on Mastodon' };
+		} else if (link.includes('bsky.app')) {
+			return { icon: '🦋', title: 'View on Bluesky' };
+		} else if (link.includes('twitter.com') || link.includes('x.com')) {
+			return { icon: '🐦', title: 'View on X' };
+		} else {
+			return { icon: '🔗', title: link };
+		}
+	}
+</script>
+
+<div class="post-meta">
+	<div class="meta-primary">
+		{#if showType}
+			<a href="/type/{getTypePlural(type).toLowerCase()}/" class="post-type">{getTypeIcon(type)} {type}</a>
+		{/if}
+		<a href={permalink} class="u-url permalink" title={formatAbsoluteDate(date)}>
+			<span class="permalink-icon">🔗</span>
+			<time class="dt-published" datetime={date}>{formatRelativeDate(date)}</time>
+		</a>
+	</div>
+	{#if (syndication && syndication.length > 0)}
+		<div class="meta-secondary">
+			{#each syndication as link (link)}
+				{@const synInfo = getSyndicationInfo(link)}
+				<a href={link} class="u-syndication syndication-link" title={synInfo.title} target="_blank" rel="noopener">
+					{synInfo.icon}
+				</a>
+			{/each}
+			<WebmentionCounts url={permalink} />
+		</div>
+	{:else}
+		<WebmentionCounts url={permalink} />
+	{/if}
+</div>
+
+<style>
+	.post-meta {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		font-size: 0.75rem;
+		color: rgba(255, 255, 255, 0.6);
+		margin-bottom: 0.5rem;
+	}
+
+	.meta-primary {
+		display: flex;
+		align-items: center;
+		gap: 0.125rem;
+		margin-left: -0.5rem;
+	}
+
+	.meta-secondary {
+		display: flex;
+		align-items: center;
+		gap: 0.125rem;
+		margin-right: -0.5rem;
+	}
+
+	.post-type,
+	.permalink,
+	.syndication-link {
+		color: inherit;
+		text-decoration: none;
+		padding: 0.25rem 0.5rem;
+		border-radius: 4px;
+		transition: background 0.15s ease, color 0.15s ease;
+	}
+
+	.post-type:hover,
+	.permalink:hover,
+	.syndication-link:hover {
+		background: rgba(255, 255, 255, 0.15);
+		color: #fff;
+	}
+
+	.permalink {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
+	.permalink-icon {
+		opacity: 0.6;
+		font-size: 0.7em;
+	}
+
+	.permalink:hover .permalink-icon {
+		opacity: 1;
+	}
+
+	.syndication-link {
+		font-size: 0.875rem;
+		opacity: 0.7;
+	}
+
+	.syndication-link:hover {
+		opacity: 1;
+	}
+</style>

--- a/src/lib/components/posts/PostsLayout.svelte
+++ b/src/lib/components/posts/PostsLayout.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		children: Snippet;
+	}
+
+	let { children }: Props = $props();
+</script>
+
+<div class="container">
+	{@render children()}
+</div>
+
+<style>
+	/*
+	 * Font Loading Strategy:
+	 * Use a system font stack with similar metrics to ff-dagny-web-pro
+	 * to minimize layout shift (CLS) during font loading.
+	 */
+	@font-face {
+		font-family: 'Dagny Fallback';
+		src: local('Avenir Next'), local('Avenir'), local('Helvetica Neue'), local('Helvetica'), local('Arial');
+		size-adjust: 100%;
+		ascent-override: 95%;
+		descent-override: 25%;
+		line-gap-override: 0%;
+	}
+
+	:global(html) {
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+		text-rendering: optimizeLegibility;
+	}
+
+	:global(body) {
+		background: #808080;
+		color: #fff;
+		font-family: ff-dagny-web-pro, 'Dagny Fallback', system-ui, -apple-system, sans-serif;
+		font-weight: 400;
+		margin: 0;
+		padding: 0;
+		font-size: 1.125rem;
+		line-height: 1.6;
+	}
+
+	.container {
+		max-width: 38rem;
+		margin: 0 auto;
+		padding: 2rem 1.5rem;
+	}
+
+	@media (max-width: 600px) {
+		:global(body) {
+			font-size: 1rem;
+		}
+
+		.container {
+			padding: 1.5rem 1rem;
+		}
+	}
+</style>

--- a/src/lib/components/posts/index.ts
+++ b/src/lib/components/posts/index.ts
@@ -1,0 +1,9 @@
+export { default as PostCard } from './PostCard.svelte';
+export { default as PostMeta } from './PostMeta.svelte';
+export { default as PostContent } from './PostContent.svelte';
+export { default as PostCategories } from './PostCategories.svelte';
+export { default as DateHeader } from './DateHeader.svelte';
+export { default as ArchiveHeader } from './ArchiveHeader.svelte';
+export { default as DateArchiveHeader } from './DateArchiveHeader.svelte';
+export { default as DropdownArchiveHeader } from './DropdownArchiveHeader.svelte';
+export { default as PostsLayout } from './PostsLayout.svelte';

--- a/src/lib/posts-types.ts
+++ b/src/lib/posts-types.ts
@@ -1,0 +1,49 @@
+// Client-safe post types and constants (no Node.js imports)
+
+export interface Post {
+	slug: string;
+	type: 'note' | 'article' | 'bookmark' | 'photo' | 'video' | 'reply' | 'media';
+	date: string;
+	title?: string;
+	summary?: string;
+	category?: string | string[];
+	content: string;
+	visibility?: string;
+	syndication?: string[];
+	filePath: string;
+}
+
+export const POST_TYPES = ['note', 'article', 'bookmark', 'photo', 'video', 'reply', 'media'] as const;
+export const POST_TYPE_PLURALS: Record<string, string> = {
+	note: 'notes',
+	article: 'articles',
+	bookmark: 'bookmarks',
+	photo: 'photos',
+	video: 'videos',
+	reply: 'replies',
+	media: 'media'
+};
+
+export function getPostPermalink(post: { date: string; slug: string }): string {
+	const date = new Date(post.date);
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const day = String(date.getDate()).padStart(2, '0');
+	return `/${year}/${month}/${day}/${post.slug}/`;
+}
+
+export function getPostsByDay(posts: Post[]): Map<string, Post[]> {
+	const byDay = new Map<string, Post[]>();
+
+	for (const post of posts) {
+		const date = new Date(post.date);
+		const dateKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+
+		if (!byDay.has(dateKey)) {
+			byDay.set(dateKey, []);
+		}
+		byDay.get(dateKey)!.push(post);
+	}
+
+	return byDay;
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -9,6 +9,17 @@ import matter from 'gray-matter';
 export type { Post } from './posts-types';
 export { POST_TYPES, POST_TYPE_PLURALS, getPostPermalink, getPostsByDay } from './posts-types';
 
+// Mapping from plural folder names to singular type names
+const PLURAL_TO_SINGULAR: Record<string, string> = {
+	notes: 'note',
+	articles: 'article',
+	bookmarks: 'bookmark',
+	photos: 'photo',
+	videos: 'video',
+	replies: 'reply',
+	media: 'media'
+};
+
 import type { Post } from './posts-types';
 
 export async function getAllPosts(): Promise<Post[]> {
@@ -38,7 +49,7 @@ export async function getAllPosts(): Promise<Post[]> {
 
 				posts.push({
 					slug,
-					type: type.slice(0, -1) as Post['type'], // Remove 's' from plural
+					type: PLURAL_TO_SINGULAR[type] as Post['type'],
 					date: dateStr,
 					title: data.title,
 					summary: data.summary,

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -96,10 +96,11 @@ export function getAllTags(posts: Post[]): Map<string, number> {
 }
 
 export function getPostsByTag(posts: Post[], tag: string): Post[] {
+	const tagLower = tag.toLowerCase();
 	return posts.filter(post => {
 		if (!post.category) return false;
 		const categories = Array.isArray(post.category) ? post.category : [post.category];
-		return categories.includes(tag);
+		return categories.some(cat => cat.toLowerCase() === tagLower);
 	});
 }
 

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,19 +1,15 @@
+// Server-only module - contains file system operations
+// For client-safe types and constants, import from '$lib/posts-types'
+
 import { readdir, readFile } from 'fs/promises';
 import { join } from 'path';
 import matter from 'gray-matter';
 
-export interface Post {
-	slug: string;
-	type: 'note' | 'article' | 'bookmark' | 'photo' | 'video' | 'reply' | 'media';
-	date: string;
-	title?: string;
-	summary?: string;
-	category?: string | string[];
-	content: string;
-	visibility?: string;
-	syndication?: string[];
-	filePath: string;
-}
+// Re-export client-safe types and functions
+export type { Post } from './posts-types';
+export { POST_TYPES, POST_TYPE_PLURALS, getPostPermalink, getPostsByDay } from './posts-types';
+
+import type { Post } from './posts-types';
 
 export async function getAllPosts(): Promise<Post[]> {
 	const contentDir = join(process.cwd(), 'content');
@@ -68,26 +64,31 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
 	return posts.find(p => p.slug === slug) || null;
 }
 
-export function getPostsByDay(posts: Post[]): Map<string, Post[]> {
-	const byDay = new Map<string, Post[]>();
+
+export function getPostsByType(posts: Post[], type: string): Post[] {
+	return posts.filter(p => p.type === type);
+}
+
+export function getAllTags(posts: Post[]): Map<string, number> {
+	const tags = new Map<string, number>();
 
 	for (const post of posts) {
-		const date = new Date(post.date);
-		const dateKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+		if (!post.category) continue;
 
-		if (!byDay.has(dateKey)) {
-			byDay.set(dateKey, []);
+		const categories = Array.isArray(post.category) ? post.category : [post.category];
+		for (const cat of categories) {
+			tags.set(cat, (tags.get(cat) || 0) + 1);
 		}
-		byDay.get(dateKey)!.push(post);
 	}
 
-	return byDay;
+	return tags;
 }
 
-export function getPostPermalink(post: Post): string {
-	const date = new Date(post.date);
-	const year = date.getFullYear();
-	const month = String(date.getMonth() + 1).padStart(2, '0');
-	const day = String(date.getDate()).padStart(2, '0');
-	return `/${year}/${month}/${day}/${post.slug}/`;
+export function getPostsByTag(posts: Post[], tag: string): Post[] {
+	return posts.filter(post => {
+		if (!post.category) return false;
+		const categories = Array.isArray(post.category) ? post.category : [post.category];
+		return categories.includes(tag);
+	});
 }
+

--- a/src/lib/utils/formatDate.ts
+++ b/src/lib/utils/formatDate.ts
@@ -1,0 +1,60 @@
+/**
+ * Format a date as a relative time string (e.g., "2 days ago", "3 months ago")
+ */
+export function formatRelativeDate(dateStr: string): string {
+	const date = new Date(dateStr);
+	const now = new Date();
+	const diffMs = now.getTime() - date.getTime();
+	const diffSeconds = Math.floor(diffMs / 1000);
+	const diffMinutes = Math.floor(diffSeconds / 60);
+	const diffHours = Math.floor(diffMinutes / 60);
+	const diffDays = Math.floor(diffHours / 24);
+	const diffWeeks = Math.floor(diffDays / 7);
+	const diffMonths = Math.floor(diffDays / 30);
+	const diffYears = Math.floor(diffDays / 365);
+
+	if (diffSeconds < 60) {
+		return 'just now';
+	} else if (diffMinutes < 60) {
+		return diffMinutes === 1 ? '1 minute ago' : `${diffMinutes} minutes ago`;
+	} else if (diffHours < 24) {
+		return diffHours === 1 ? '1 hour ago' : `${diffHours} hours ago`;
+	} else if (diffDays < 7) {
+		return diffDays === 1 ? 'yesterday' : `${diffDays} days ago`;
+	} else if (diffWeeks < 4) {
+		return diffWeeks === 1 ? '1 week ago' : `${diffWeeks} weeks ago`;
+	} else if (diffMonths < 12) {
+		return diffMonths === 1 ? '1 month ago' : `${diffMonths} months ago`;
+	} else {
+		return diffYears === 1 ? '1 year ago' : `${diffYears} years ago`;
+	}
+}
+
+/**
+ * Format a date as an absolute string for tooltip/title
+ */
+export function formatAbsoluteDate(dateStr: string): string {
+	const date = new Date(dateStr);
+	return date.toLocaleString('en-US', {
+		weekday: 'long',
+		month: 'long',
+		day: 'numeric',
+		year: 'numeric',
+		hour: 'numeric',
+		minute: '2-digit'
+	});
+}
+
+/**
+ * Format a date for display in post metadata (shorter format)
+ */
+export function formatPostDate(dateStr: string): string {
+	const date = new Date(dateStr);
+	return date.toLocaleString('en-US', {
+		month: 'short',
+		day: 'numeric',
+		year: 'numeric',
+		hour: 'numeric',
+		minute: '2-digit'
+	});
+}

--- a/src/lib/utils/renderContent.ts
+++ b/src/lib/utils/renderContent.ts
@@ -1,0 +1,148 @@
+import { marked } from 'marked';
+
+// Configure marked for safe HTML rendering
+marked.setOptions({
+	gfm: true,
+	breaks: true
+});
+
+// oEmbed patterns for common providers
+const OEMBED_PATTERNS: Array<{
+	pattern: RegExp;
+	getEmbed: (match: RegExpMatchArray) => string;
+}> = [
+	// YouTube - various URL formats
+	{
+		pattern: /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})(?:\S*)?/g,
+		getEmbed: (match) => {
+			const videoId = match[1];
+			return `<div class="embed embed-video"><iframe src="https://www.youtube.com/embed/${videoId}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe></div>`;
+		}
+	},
+	// Vimeo
+	{
+		pattern: /(?:https?:\/\/)?(?:www\.)?vimeo\.com\/(\d+)(?:\S*)?/g,
+		getEmbed: (match) => {
+			const videoId = match[1];
+			return `<div class="embed embed-video"><iframe src="https://player.vimeo.com/video/${videoId}" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen loading="lazy"></iframe></div>`;
+		}
+	}
+];
+
+// URL pattern for auto-linking plain URLs
+const URL_PATTERN = /(?<!["'=])(https?:\/\/[^\s<>[\]()]+)(?![^<]*>|[^<>]*<\/a>)/g;
+
+// Mastodon handle pattern: @user@instance.tld
+const MASTODON_HANDLE_PATTERN = /(?<![a-zA-Z0-9])@([a-zA-Z0-9_]+)@([a-zA-Z0-9][a-zA-Z0-9.-]+\.[a-zA-Z]{2,})(?![^<]*>|[^<>]*<\/a>)/g;
+
+// Bluesky handle pattern: @user.bsky.social or @handle.tld
+const BLUESKY_HANDLE_PATTERN = /(?<![a-zA-Z0-9@])@([a-zA-Z0-9][a-zA-Z0-9.-]*\.bsky\.social)(?![^<]*>|[^<>]*<\/a>)/g;
+
+/**
+ * Extract domain from URL for display
+ */
+function getDomain(url: string): string {
+	try {
+		const parsed = new URL(url);
+		return parsed.hostname.replace(/^www\./, '');
+	} catch {
+		return url;
+	}
+}
+
+/**
+ * Check if a URL matches an oEmbed pattern
+ */
+function matchesOembedPattern(url: string): boolean {
+	return OEMBED_PATTERNS.some(({ pattern }) => {
+		pattern.lastIndex = 0;
+		return pattern.test(url);
+	});
+}
+
+/**
+ * Process oEmbed URLs in content
+ */
+function processOembeds(content: string): string {
+	let result = content;
+
+	for (const { pattern, getEmbed } of OEMBED_PATTERNS) {
+		pattern.lastIndex = 0;
+		result = result.replace(pattern, (fullMatch, ...groups) => {
+			// Check if this URL is already inside a link or other HTML
+			const beforeMatch = result.substring(0, result.indexOf(fullMatch));
+			const inTag = /<[^>]*$/.test(beforeMatch);
+			if (inTag) return fullMatch;
+
+			return getEmbed([fullMatch, ...groups] as RegExpMatchArray);
+		});
+	}
+
+	return result;
+}
+
+/**
+ * Auto-link Mastodon handles (@user@instance.tld → https://instance.tld/@user)
+ */
+function autoLinkMastodonHandles(content: string): string {
+	return content.replace(MASTODON_HANDLE_PATTERN, (_match, user, instance) => {
+		const url = `https://${instance}/@${user}`;
+		return `<a href="${url}" target="_blank" rel="noopener">@${user}@${instance}</a>`;
+	});
+}
+
+/**
+ * Auto-link Bluesky handles (@user.bsky.social → https://bsky.app/profile/user.bsky.social)
+ */
+function autoLinkBlueskyHandles(content: string): string {
+	return content.replace(BLUESKY_HANDLE_PATTERN, (_match, handle) => {
+		const url = `https://bsky.app/profile/${handle}`;
+		return `<a href="${url}" target="_blank" rel="noopener">@${handle}</a>`;
+	});
+}
+
+/**
+ * Auto-link plain URLs that aren't already linked and aren't oEmbed-able
+ */
+function autoLinkUrls(content: string): string {
+	return content.replace(URL_PATTERN, (url) => {
+		// Skip if it matches an oEmbed pattern (those get embedded instead)
+		if (matchesOembedPattern(url)) {
+			return url;
+		}
+		const domain = getDomain(url);
+		return `<a href="${url}" target="_blank" rel="noopener">${domain}</a>`;
+	});
+}
+
+/**
+ * Render content with markdown, auto-linking, and oEmbed support
+ *
+ * @param content - Raw content string (may contain markdown, URLs, etc.)
+ * @returns HTML string ready for rendering with {@html}
+ */
+export function renderContent(content: string): string {
+	if (!content) return '';
+
+	// Step 1: Process oEmbeds first (before markdown to avoid interference)
+	let processed = processOembeds(content);
+
+	// Step 2: Auto-link social handles (before URLs to avoid conflicts)
+	processed = autoLinkMastodonHandles(processed);
+	processed = autoLinkBlueskyHandles(processed);
+
+	// Step 3: Auto-link remaining URLs
+	processed = autoLinkUrls(processed);
+
+	// Step 4: Run through marked for markdown processing
+	const html = marked.parse(processed, { async: false }) as string;
+
+	return html;
+}
+
+/**
+ * Render content synchronously (for use in components)
+ */
+export function renderContentSync(content: string): string {
+	return renderContent(content);
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -480,7 +480,6 @@
         href="https://unpkg.com/telescopic-text@1.2.4/lib/index.css"
         rel="stylesheet"
     />
-    <link rel="stylesheet" href="https://use.typekit.net/rfh8wvj.css" />
     <link rel="micropub" href="https://kit.caseyagollan.com/micropub" />
     <link
         rel="authorization_endpoint"

--- a/src/routes/[year]/+page.svelte
+++ b/src/routes/[year]/+page.svelte
@@ -1,227 +1,34 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import Nav from '$lib/components/Nav.svelte';
+	import { PostsLayout, DateArchiveHeader, DateHeader, PostCard } from '$lib/components/posts';
 
 	let { data }: { data: PageData } = $props();
-
-	function formatDate(dateStr: string) {
-		const [year, month, day] = dateStr.split('-');
-		return { year, month, day };
-	}
-
-	function formatPostDate(dateStr: string) {
-		const date = new Date(dateStr);
-		return date.toLocaleString('en-US', {
-			month: 'short',
-			day: 'numeric',
-			year: 'numeric',
-			hour: 'numeric',
-			minute: '2-digit'
-		});
-	}
-
-	function truncate(text: string, length: number = 280) {
-		if (text.length <= length) return text;
-		return text.slice(0, length).trim() + '...';
-	}
-
-	function getPermalink(post: { date: string; slug: string }) {
-		const date = new Date(post.date);
-		const year = date.getFullYear();
-		const month = String(date.getMonth() + 1).padStart(2, '0');
-		const day = String(date.getDate()).padStart(2, '0');
-		return `/${year}/${month}/${day}/${post.slug}/`;
-	}
 </script>
 
 <svelte:head>
-	<title>📡 {data.year} - Casey Gollan</title>
+	<title>{data.year} - Casey Gollan</title>
 	<meta name="description" content="Posts from {data.year} by Casey Gollan" />
-	<link rel="stylesheet" href="https://use.typekit.net/rfh8wvj.css" />
 </svelte:head>
 
 <Nav currentPage="posts" showPostsLink={true} />
 
-<div class="container">
-
-	<div class="header">
-		<span class="pill">📡 {data.year} ({data.totalPosts})</span>
-	</div>
+<PostsLayout>
+	<DateArchiveHeader year={data.year} count={data.totalPosts} />
 
 	<div class="posts-list h-feed">
 		{#each data.postsByDay as [dateKey, postsForDay] (dateKey)}
-			{@const dateInfo = formatDate(dateKey)}
-			<h2 class="date-header">
-				<div class="meta-pill">
-					<a href="/{dateInfo.year}/" class="meta-segment">{dateInfo.year}</a>
-					<a href="/{dateInfo.year}/{dateInfo.month}/" class="meta-segment">{dateInfo.month}</a>
-					<a href="/{dateInfo.year}/{dateInfo.month}/{dateInfo.day}/" class="meta-segment"
-						>{dateInfo.day}</a
-					>
-				</div>
-			</h2>
+			<DateHeader {dateKey} />
 
 			{#each postsForDay as post (post.slug)}
-				<article class="h-entry post">
-					<div class="post-meta">
-						<span class="post-type">{post.type}</span>
-						<a href={getPermalink(post)} class="u-url permalink">
-							<time class="dt-published" datetime={post.date}>{formatPostDate(post.date)}</time>
-						</a>
-					</div>
-
-					{#if post.title}
-						<h3 class="p-name post-title">{post.title}</h3>
-					{/if}
-
-					<div class="e-content post-content">
-						{#if post.summary}
-							<p>{post.summary}</p>
-						{:else}
-							<p>{truncate(post.content)}</p>
-						{/if}
-					</div>
-
-					{#if post.category}
-						<div class="post-categories">
-							{#if typeof post.category === 'string'}
-								<span class="category-tag">{post.category}</span>
-							{:else if Array.isArray(post.category)}
-								{#each post.category as cat (cat)}
-									<span class="category-tag">{cat}</span>
-								{/each}
-							{/if}
-						</div>
-					{/if}
-				</article>
+				<PostCard {post} />
 			{/each}
 		{/each}
 	</div>
-</div>
+</PostsLayout>
 
 <style>
-	:global(body) {
-		background: gray;
-		color: white;
-		font-family: ff-dagny-web-pro, sans-serif;
-		margin: 0;
-		padding: 0;
-	}
-
-	.container {
-		max-width: 800px;
-		margin: 0 auto;
-		padding: 2rem;
-	}
-
-	.meta-pill {
-		display: inline-flex;
-		background: blue;
-		border-radius: 5px;
-		overflow: hidden;
-	}
-
-	.meta-segment {
-		padding: 0.5rem 1rem;
-		color: white;
-		text-decoration: none;
-		border-right: 1px solid rgba(255, 255, 255, 0.3);
-	}
-
-	.meta-segment:last-child {
-		border-right: none;
-	}
-
-	.meta-segment:hover {
-		background: rgb(73, 73, 255);
-	}
-
-	.header {
-		margin-bottom: 2rem;
-	}
-
-	.pill {
-		background: blue;
-		color: white;
-		padding: 0.5rem 1rem;
-		border-radius: 5px;
-		display: inline-block;
-		font-size: 1.5rem;
-	}
-
 	.posts-list {
 		line-height: 1.6;
-	}
-
-	.date-header {
-		margin: 2rem 0 1rem;
-		font-size: 1rem;
-		font-weight: normal;
-		position: sticky;
-		top: 0;
-		background: gray;
-		padding: 0.5rem 0;
-		z-index: 10;
-	}
-
-	.post {
-		margin-bottom: 2rem;
-		padding-bottom: 2rem;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-	}
-
-	.post:last-child {
-		border-bottom: none;
-	}
-
-	.post-meta {
-		display: flex;
-		gap: 1rem;
-		font-size: 0.9rem;
-		opacity: 0.8;
-		margin-bottom: 0.5rem;
-	}
-
-	.post-type {
-		text-transform: uppercase;
-		font-weight: bold;
-		color: rgb(73, 73, 255);
-	}
-
-	.permalink {
-		color: inherit;
-		text-decoration: none;
-	}
-
-	.permalink:hover {
-		text-decoration: underline;
-	}
-
-	.post-title {
-		font-size: 1.3rem;
-		margin: 0.5rem 0;
-		font-weight: bold;
-	}
-
-	.post-content {
-		margin: 1rem 0;
-	}
-
-	.post-content p {
-		margin: 0.5rem 0;
-	}
-
-	.post-categories {
-		display: flex;
-		gap: 0.5rem;
-		flex-wrap: wrap;
-		margin-top: 1rem;
-	}
-
-	.category-tag {
-		background: rgba(255, 255, 255, 0.1);
-		padding: 0.25rem 0.75rem;
-		border-radius: 3px;
-		font-size: 0.85rem;
 	}
 </style>

--- a/src/routes/[year]/[month]/+page.svelte
+++ b/src/routes/[year]/[month]/+page.svelte
@@ -1,37 +1,9 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import Nav from '$lib/components/Nav.svelte';
+	import { PostsLayout, DateArchiveHeader, DateHeader, PostCard } from '$lib/components/posts';
 
 	let { data }: { data: PageData } = $props();
-
-	function formatDate(dateStr: string) {
-		const [year, month, day] = dateStr.split('-');
-		return { year, month, day };
-	}
-
-	function formatPostDate(dateStr: string) {
-		const date = new Date(dateStr);
-		return date.toLocaleString('en-US', {
-			month: 'short',
-			day: 'numeric',
-			year: 'numeric',
-			hour: 'numeric',
-			minute: '2-digit'
-		});
-	}
-
-	function truncate(text: string, length: number = 280) {
-		if (text.length <= length) return text;
-		return text.slice(0, length).trim() + '...';
-	}
-
-	function getPermalink(post: { date: string; slug: string }) {
-		const date = new Date(post.date);
-		const year = date.getFullYear();
-		const month = String(date.getMonth() + 1).padStart(2, '0');
-		const day = String(date.getDate()).padStart(2, '0');
-		return `/${year}/${month}/${day}/${post.slug}/`;
-	}
 
 	const monthName = new Date(`${data.year}-${data.month}-01`).toLocaleString('en-US', {
 		month: 'long'
@@ -39,194 +11,28 @@
 </script>
 
 <svelte:head>
-	<title>📡 {monthName} {data.year} - Casey Gollan</title>
+	<title>{monthName} {data.year} - Casey Gollan</title>
 	<meta name="description" content="Posts from {monthName} {data.year} by Casey Gollan" />
-	<link rel="stylesheet" href="https://use.typekit.net/rfh8wvj.css" />
 </svelte:head>
 
 <Nav currentPage="posts" showPostsLink={true} />
 
-<div class="container">
-
-	<div class="header">
-		<span class="pill">📡 {monthName} {data.year} ({data.totalPosts})</span>
-	</div>
+<PostsLayout>
+	<DateArchiveHeader year={data.year} month={data.month} count={data.totalPosts} />
 
 	<div class="posts-list h-feed">
 		{#each data.postsByDay as [dateKey, postsForDay] (dateKey)}
-			{@const dateInfo = formatDate(dateKey)}
-			<h2 class="date-header">
-				<div class="meta-pill">
-					<a href="/{dateInfo.year}/" class="meta-segment">{dateInfo.year}</a>
-					<a href="/{dateInfo.year}/{dateInfo.month}/" class="meta-segment">{dateInfo.month}</a>
-					<a href="/{dateInfo.year}/{dateInfo.month}/{dateInfo.day}/" class="meta-segment"
-						>{dateInfo.day}</a
-					>
-				</div>
-			</h2>
+			<DateHeader {dateKey} />
 
 			{#each postsForDay as post (post.slug)}
-				<article class="h-entry post">
-					<div class="post-meta">
-						<span class="post-type">{post.type}</span>
-						<a href={getPermalink(post)} class="u-url permalink">
-							<time class="dt-published" datetime={post.date}>{formatPostDate(post.date)}</time>
-						</a>
-					</div>
-
-					{#if post.title}
-						<h3 class="p-name post-title">{post.title}</h3>
-					{/if}
-
-					<div class="e-content post-content">
-						{#if post.summary}
-							<p>{post.summary}</p>
-						{:else}
-							<p>{truncate(post.content)}</p>
-						{/if}
-					</div>
-
-					{#if post.category}
-						<div class="post-categories">
-							{#if typeof post.category === 'string'}
-								<span class="category-tag">{post.category}</span>
-							{:else if Array.isArray(post.category)}
-								{#each post.category as cat (cat)}
-									<span class="category-tag">{cat}</span>
-								{/each}
-							{/if}
-						</div>
-					{/if}
-				</article>
+				<PostCard {post} />
 			{/each}
 		{/each}
 	</div>
-</div>
+</PostsLayout>
 
 <style>
-	:global(body) {
-		background: gray;
-		color: white;
-		font-family: ff-dagny-web-pro, sans-serif;
-		margin: 0;
-		padding: 0;
-	}
-
-	.container {
-		max-width: 800px;
-		margin: 0 auto;
-		padding: 2rem;
-	}
-
-
-	.meta-pill {
-		display: inline-flex;
-		background: blue;
-		border-radius: 5px;
-		overflow: hidden;
-	}
-
-	.meta-segment {
-		padding: 0.5rem 1rem;
-		color: white;
-		text-decoration: none;
-		border-right: 1px solid rgba(255, 255, 255, 0.3);
-	}
-
-	.meta-segment:last-child {
-		border-right: none;
-	}
-
-	.meta-segment:hover {
-		background: rgb(73, 73, 255);
-	}
-
-	.header {
-		margin-bottom: 2rem;
-	}
-
-	.pill {
-		background: blue;
-		color: white;
-		padding: 0.5rem 1rem;
-		border-radius: 5px;
-		display: inline-block;
-		font-size: 1.5rem;
-	}
-
 	.posts-list {
 		line-height: 1.6;
-	}
-
-	.date-header {
-		margin: 2rem 0 1rem;
-		font-size: 1rem;
-		font-weight: normal;
-		position: sticky;
-		top: 0;
-		background: gray;
-		padding: 0.5rem 0;
-		z-index: 10;
-	}
-
-	.post {
-		margin-bottom: 2rem;
-		padding-bottom: 2rem;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-	}
-
-	.post:last-child {
-		border-bottom: none;
-	}
-
-	.post-meta {
-		display: flex;
-		gap: 1rem;
-		font-size: 0.9rem;
-		opacity: 0.8;
-		margin-bottom: 0.5rem;
-	}
-
-	.post-type {
-		text-transform: uppercase;
-		font-weight: bold;
-		color: rgb(73, 73, 255);
-	}
-
-	.permalink {
-		color: inherit;
-		text-decoration: none;
-	}
-
-	.permalink:hover {
-		text-decoration: underline;
-	}
-
-	.post-title {
-		font-size: 1.3rem;
-		margin: 0.5rem 0;
-		font-weight: bold;
-	}
-
-	.post-content {
-		margin: 1rem 0;
-	}
-
-	.post-content p {
-		margin: 0.5rem 0;
-	}
-
-	.post-categories {
-		display: flex;
-		gap: 0.5rem;
-		flex-wrap: wrap;
-		margin-top: 1rem;
-	}
-
-	.category-tag {
-		background: rgba(255, 255, 255, 0.1);
-		padding: 0.25rem 0.75rem;
-		border-radius: 3px;
-		font-size: 0.85rem;
 	}
 </style>

--- a/src/routes/[year]/[month]/[day]/+page.svelte
+++ b/src/routes/[year]/[month]/[day]/+page.svelte
@@ -1,32 +1,9 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import Nav from '$lib/components/Nav.svelte';
+	import { PostsLayout, DateArchiveHeader, PostCard } from '$lib/components/posts';
 
 	let { data }: { data: PageData } = $props();
-
-	function formatPostDate(dateStr: string) {
-		const date = new Date(dateStr);
-		return date.toLocaleString('en-US', {
-			month: 'short',
-			day: 'numeric',
-			year: 'numeric',
-			hour: 'numeric',
-			minute: '2-digit'
-		});
-	}
-
-	function truncate(text: string, length: number = 280) {
-		if (text.length <= length) return text;
-		return text.slice(0, length).trim() + '...';
-	}
-
-	function getPermalink(post: { date: string; slug: string }) {
-		const date = new Date(post.date);
-		const year = date.getFullYear();
-		const month = String(date.getMonth() + 1).padStart(2, '0');
-		const day = String(date.getDate()).padStart(2, '0');
-		return `/${year}/${month}/${day}/${post.slug}/`;
-	}
 
 	const fullDate = new Date(`${data.year}-${data.month}-${data.day}`).toLocaleString('en-US', {
 		month: 'long',
@@ -36,148 +13,24 @@
 </script>
 
 <svelte:head>
-	<title>📡 {fullDate} - Casey Gollan</title>
+	<title>{fullDate} - Casey Gollan</title>
 	<meta name="description" content="Posts from {fullDate} by Casey Gollan" />
-	<link rel="stylesheet" href="https://use.typekit.net/rfh8wvj.css" />
 </svelte:head>
 
 <Nav currentPage="posts" showPostsLink={true} />
 
-<div class="container">
-
-	<div class="header">
-		<span class="pill">📡 {fullDate} ({data.totalPosts})</span>
-	</div>
+<PostsLayout>
+	<DateArchiveHeader year={data.year} month={data.month} day={data.day} count={data.totalPosts} />
 
 	<div class="posts-list h-feed">
 		{#each data.posts as post (post.slug)}
-			<article class="h-entry post">
-				<div class="post-meta">
-					<span class="post-type">{post.type}</span>
-					<a href={getPermalink(post)} class="u-url permalink">
-						<time class="dt-published" datetime={post.date}>{formatPostDate(post.date)}</time>
-					</a>
-				</div>
-
-				{#if post.title}
-					<h3 class="p-name post-title">{post.title}</h3>
-				{/if}
-
-				<div class="e-content post-content">
-					{#if post.summary}
-						<p>{post.summary}</p>
-					{:else}
-						<p>{truncate(post.content)}</p>
-					{/if}
-				</div>
-
-				{#if post.category}
-					<div class="post-categories">
-						{#if typeof post.category === 'string'}
-							<span class="category-tag">{post.category}</span>
-						{:else if Array.isArray(post.category)}
-							{#each post.category as cat (cat)}
-								<span class="category-tag">{cat}</span>
-							{/each}
-						{/if}
-					</div>
-				{/if}
-			</article>
+			<PostCard {post} />
 		{/each}
 	</div>
-</div>
+</PostsLayout>
 
 <style>
-	:global(body) {
-		background: gray;
-		color: white;
-		font-family: ff-dagny-web-pro, sans-serif;
-		margin: 0;
-		padding: 0;
-	}
-
-	.container {
-		max-width: 800px;
-		margin: 0 auto;
-		padding: 2rem;
-	}
-
-
-	.header {
-		margin-bottom: 2rem;
-	}
-
-	.pill {
-		background: blue;
-		color: white;
-		padding: 0.5rem 1rem;
-		border-radius: 5px;
-		display: inline-block;
-		font-size: 1.5rem;
-	}
-
 	.posts-list {
 		line-height: 1.6;
-	}
-
-	.post {
-		margin-bottom: 2rem;
-		padding-bottom: 2rem;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-	}
-
-	.post:last-child {
-		border-bottom: none;
-	}
-
-	.post-meta {
-		display: flex;
-		gap: 1rem;
-		font-size: 0.9rem;
-		opacity: 0.8;
-		margin-bottom: 0.5rem;
-	}
-
-	.post-type {
-		text-transform: uppercase;
-		font-weight: bold;
-		color: rgb(73, 73, 255);
-	}
-
-	.permalink {
-		color: inherit;
-		text-decoration: none;
-	}
-
-	.permalink:hover {
-		text-decoration: underline;
-	}
-
-	.post-title {
-		font-size: 1.3rem;
-		margin: 0.5rem 0;
-		font-weight: bold;
-	}
-
-	.post-content {
-		margin: 1rem 0;
-	}
-
-	.post-content p {
-		margin: 0.5rem 0;
-	}
-
-	.post-categories {
-		display: flex;
-		gap: 0.5rem;
-		flex-wrap: wrap;
-		margin-top: 1rem;
-	}
-
-	.category-tag {
-		background: rgba(255, 255, 255, 0.1);
-		padding: 0.25rem 0.75rem;
-		border-radius: 3px;
-		font-size: 0.85rem;
 	}
 </style>

--- a/src/routes/[year]/[month]/[day]/[slug]/+page.svelte
+++ b/src/routes/[year]/[month]/[day]/[slug]/+page.svelte
@@ -2,7 +2,7 @@
 	import type { PageData } from './$types';
 	import Nav from '$lib/components/Nav.svelte';
 	import Webmentions from '$lib/components/Webmentions.svelte';
-	import { PostsLayout, DateArchiveHeader, PostMeta, PostContent, PostCategories } from '$lib/components/posts';
+	import { PostsLayout, DateArchiveHeader, PostMeta, PostContent } from '$lib/components/posts';
 
 	let { data }: { data: PageData } = $props();
 
@@ -29,6 +29,7 @@
 			date={data.post.date}
 			{permalink}
 			syndication={data.post.syndication}
+			category={data.post.category}
 		/>
 
 		{#if data.post.title}
@@ -36,8 +37,6 @@
 		{/if}
 
 		<PostContent content={data.post.content} />
-
-		<PostCategories category={data.post.category} />
 
 		<Webmentions url={permalink} />
 	</article>

--- a/src/routes/[year]/[month]/[day]/[slug]/+page.svelte
+++ b/src/routes/[year]/[month]/[day]/[slug]/+page.svelte
@@ -2,31 +2,9 @@
 	import type { PageData } from './$types';
 	import Nav from '$lib/components/Nav.svelte';
 	import Webmentions from '$lib/components/Webmentions.svelte';
+	import { PostsLayout, DateArchiveHeader, PostMeta, PostContent, PostCategories } from '$lib/components/posts';
 
 	let { data }: { data: PageData } = $props();
-
-	function formatPostDate(dateStr: string) {
-		const date = new Date(dateStr);
-		return date.toLocaleString('en-US', {
-			month: 'short',
-			day: 'numeric',
-			year: 'numeric',
-			hour: 'numeric',
-			minute: '2-digit'
-		});
-	}
-
-	function getSyndicationInfo(link: string): { icon: string; title: string } {
-		if (link.includes('social.coop') || link.includes('mastodon')) {
-			return { icon: '🐘', title: 'View on Mastodon' };
-		} else if (link.includes('bsky.app')) {
-			return { icon: '🦋', title: 'View on Bluesky' };
-		} else if (link.includes('twitter.com') || link.includes('x.com')) {
-			return { icon: '🐦', title: 'View on X' };
-		} else {
-			return { icon: '🔗', title: link };
-		}
-	}
 
 	const permalink = `/${data.year}/${data.month}/${data.day}/${data.post.slug}/`;
 </script>
@@ -35,145 +13,45 @@
 	<title>{data.post.title || data.post.type} - Casey Gollan</title>
 	<meta name="description" content={data.post.summary || data.post.content.slice(0, 160)} />
 	<link rel="canonical" href="https://caseyagollan.com{permalink}" />
-	<link rel="stylesheet" href="https://use.typekit.net/rfh8wvj.css" />
 </svelte:head>
 
 <Nav currentPage="posts" showPostsLink={true} />
 
-<div class="container">
+<PostsLayout>
+	<DateArchiveHeader year={data.year} month={data.month} day={data.day} />
+
 	<article class="h-entry post">
 		<!-- Hidden h-card for author info - required by Bridgy and other IndieWeb tools -->
-		<a href="https://caseyagollan.com" class="p-author h-card" style="display:none;">Casey Gollan</a>
+		<a href="https://caseyagollan.com" class="p-author h-card" hidden>Casey Gollan</a>
 
-		<div class="post-meta">
-			<span class="post-type">{data.post.type}</span>
-			<a href={permalink} class="u-url permalink">
-				<time class="dt-published" datetime={data.post.date}>{formatPostDate(data.post.date)}</time>
-			</a>
-			{#if data.post.syndication && data.post.syndication.length > 0}
-				{#each data.post.syndication as link}
-					{@const synInfo = getSyndicationInfo(link)}
-					<a href={link} class="u-syndication syndication-link" title={synInfo.title} target="_blank" rel="noopener">
-						{synInfo.icon}
-					</a>
-				{/each}
-			{/if}
-		</div>
+		<PostMeta
+			type={data.post.type}
+			date={data.post.date}
+			{permalink}
+			syndication={data.post.syndication}
+		/>
 
 		{#if data.post.title}
 			<h1 class="p-name post-title">{data.post.title}</h1>
 		{/if}
 
-		<div class="e-content post-content">
-			{@html data.post.content}
-		</div>
+		<PostContent content={data.post.content} />
 
-		{#if data.post.category}
-			<div class="post-categories">
-				{#if typeof data.post.category === 'string'}
-					<span class="category-tag p-category">{data.post.category}</span>
-				{:else if Array.isArray(data.post.category)}
-					{#each data.post.category as cat (cat)}
-						<span class="category-tag p-category">{cat}</span>
-					{/each}
-				{/if}
-			</div>
-		{/if}
+		<PostCategories category={data.post.category} />
 
 		<Webmentions url={permalink} />
 	</article>
-</div>
+</PostsLayout>
 
 <style>
-	:global(body) {
-		background: gray;
-		color: white;
-		font-family: ff-dagny-web-pro, sans-serif;
-		margin: 0;
-		padding: 0;
-	}
-
-	.container {
-		max-width: 800px;
-		margin: 0 auto;
-		padding: 2rem;
-	}
-
 	.post {
 		margin-bottom: 2rem;
 	}
 
-	.post-meta {
-		display: flex;
-		gap: 1rem;
-		font-size: 0.9rem;
-		opacity: 0.8;
-		margin-bottom: 0.5rem;
-	}
-
-	.post-type {
-		text-transform: uppercase;
-		font-weight: bold;
-		color: rgb(73, 73, 255);
-	}
-
-	.permalink {
-		color: inherit;
-		text-decoration: none;
-	}
-
-	.permalink:hover {
-		text-decoration: underline;
-	}
-
 	.post-title {
-		font-size: 2rem;
+		font-size: 1.75rem;
+		line-height: 1.25;
 		margin: 0.5rem 0 1rem;
-		font-weight: bold;
-	}
-
-	.post-content {
-		margin: 1rem 0;
-		line-height: 1.6;
-	}
-
-	.post-content :global(p) {
-		margin: 1rem 0;
-	}
-
-	.post-content :global(a) {
-		color: rgb(150, 150, 255);
-	}
-
-	.post-content :global(blockquote) {
-		border-left: 3px solid rgba(255, 255, 255, 0.3);
-		margin-left: 0;
-		padding-left: 1rem;
-		font-style: italic;
-	}
-
-	.post-categories {
-		display: flex;
-		gap: 0.5rem;
-		flex-wrap: wrap;
-		margin-top: 2rem;
-	}
-
-	.category-tag {
-		background: rgba(255, 255, 255, 0.1);
-		padding: 0.25rem 0.75rem;
-		border-radius: 3px;
-		font-size: 0.85rem;
-	}
-
-	.syndication-link {
-		text-decoration: none;
-		font-size: 1.1em;
-		opacity: 0.8;
-		transition: opacity 0.2s;
-	}
-
-	.syndication-link:hover {
-		opacity: 1;
+		font-weight: 600;
 	}
 </style>

--- a/src/routes/posts/+page.svelte
+++ b/src/routes/posts/+page.svelte
@@ -4,8 +4,6 @@
 	import { PostCard, DateHeader, PostsLayout } from '$lib/components/posts';
 
 	let { data }: { data: PageData } = $props();
-
-	const countText = $derived(data.totalPosts === 1 ? '1 post' : `${data.totalPosts} posts`);
 </script>
 
 <svelte:head>
@@ -18,11 +16,6 @@
 <Nav currentPage="posts" />
 
 <PostsLayout>
-	<div class="header">
-		<span class="pill">Posts</span>
-		<p class="count-description">{countText}</p>
-	</div>
-
 	<div class="posts-list h-feed">
 		{#each data.postsByDay as [dateKey, postsForDay] (dateKey)}
 			<DateHeader {dateKey} />
@@ -35,26 +28,6 @@
 </PostsLayout>
 
 <style>
-	.header {
-		margin-bottom: 3rem;
-	}
-
-	.pill {
-		background: #0000ff;
-		color: #fff;
-		padding: 0.5rem 1rem;
-		border-radius: 4px;
-		display: inline-block;
-		font-size: 1.25rem;
-		font-weight: 500;
-	}
-
-	.count-description {
-		margin: 0.75rem 0 0;
-		font-size: 0.875rem;
-		color: rgba(255, 255, 255, 0.7);
-	}
-
 	.posts-list {
 		line-height: 1.6;
 	}

--- a/src/routes/tag/[tag]/+page.server.ts
+++ b/src/routes/tag/[tag]/+page.server.ts
@@ -1,0 +1,35 @@
+import { getAllPosts, getPostsByTag, getPostsByDay, getAllTags } from '$lib/posts';
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ params }) => {
+	const { tag } = params;
+
+	const allPosts = await getAllPosts();
+	const posts = getPostsByTag(allPosts, tag);
+
+	if (posts.length === 0) {
+		throw error(404, `No posts found with tag "${tag}"`);
+	}
+
+	const postsByDay = getPostsByDay(posts);
+	const postsByDayArray = Array.from(postsByDay.entries()).sort((a, b) => b[0].localeCompare(a[0]));
+
+	// Get all tags with counts, sorted by count descending
+	const tagCounts = getAllTags(allPosts);
+	const allTags = Array.from(tagCounts.entries())
+		.sort((a, b) => b[1] - a[1])
+		.map(([tagName, count]) => ({
+			value: tagName,
+			label: `#${tagName}`,
+			href: `/tag/${tagName.toLowerCase()}/`,
+			count
+		}));
+
+	return {
+		tag,
+		postsByDay: postsByDayArray,
+		totalPosts: posts.length,
+		allTags
+	};
+};

--- a/src/routes/tag/[tag]/+page.svelte
+++ b/src/routes/tag/[tag]/+page.svelte
@@ -4,12 +4,6 @@
 	import { PostCard, DateHeader, DropdownArchiveHeader, PostsLayout } from '$lib/components/posts';
 
 	let { data }: { data: PageData } = $props();
-
-	const countDescription = $derived(
-		data.totalPosts === 1
-			? `1 post tagged #${data.tag}`
-			: `${data.totalPosts} posts tagged #${data.tag}`
-	);
 </script>
 
 <svelte:head>
@@ -25,7 +19,7 @@
 	<DropdownArchiveHeader
 		current="#{data.tag}"
 		options={data.allTags}
-		{countDescription}
+		count={data.totalPosts}
 	/>
 
 	<div class="posts-list h-feed">

--- a/src/routes/tag/[tag]/+page.svelte
+++ b/src/routes/tag/[tag]/+page.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import Nav from '$lib/components/Nav.svelte';
+	import { PostCard, DateHeader, DropdownArchiveHeader, PostsLayout } from '$lib/components/posts';
+
+	let { data }: { data: PageData } = $props();
+
+	const countDescription = $derived(
+		data.totalPosts === 1
+			? `1 post tagged #${data.tag}`
+			: `${data.totalPosts} posts tagged #${data.tag}`
+	);
+</script>
+
+<svelte:head>
+	<title>#{data.tag} - Casey Gollan</title>
+	<meta name="description" content="Posts tagged #{data.tag} by Casey Gollan" />
+	<meta property="og:title" content="#{data.tag} - Casey Gollan" />
+	<meta property="og:type" content="website" />
+</svelte:head>
+
+<Nav currentPage="posts" />
+
+<PostsLayout>
+	<DropdownArchiveHeader
+		current="#{data.tag}"
+		options={data.allTags}
+		{countDescription}
+	/>
+
+	<div class="posts-list h-feed">
+		{#each data.postsByDay as [dateKey, postsForDay] (dateKey)}
+			<DateHeader {dateKey} />
+
+			{#each postsForDay as post (post.slug)}
+				<PostCard {post} activeTag={data.tag} />
+			{/each}
+		{/each}
+	</div>
+</PostsLayout>
+
+<style>
+	.posts-list {
+		line-height: 1.6;
+	}
+</style>

--- a/src/routes/type/[type]/+page.server.ts
+++ b/src/routes/type/[type]/+page.server.ts
@@ -1,0 +1,56 @@
+import { getAllPosts, getPostsByType, getPostsByDay, POST_TYPES, POST_TYPE_PLURALS } from '$lib/posts';
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+const TYPE_ICONS: Record<string, string> = {
+	note: '📝',
+	article: '📄',
+	bookmark: '🔖',
+	photo: '📷',
+	video: '🎬',
+	reply: '💬',
+	media: '🎵'
+};
+
+export const load: PageServerLoad = async ({ params }) => {
+	const { type } = params;
+
+	// Validate type - accept both singular and plural forms
+	const singularType = Object.entries(POST_TYPE_PLURALS).find(
+		([singular, plural]) => plural === type || singular === type
+	)?.[0];
+
+	if (!singularType || !POST_TYPES.includes(singularType as typeof POST_TYPES[number])) {
+		throw error(404, `Post type "${type}" not found`);
+	}
+
+	const allPosts = await getAllPosts();
+	const posts = getPostsByType(allPosts, singularType);
+	const postsByDay = getPostsByDay(posts);
+	const postsByDayArray = Array.from(postsByDay.entries()).sort((a, b) => b[0].localeCompare(a[0]));
+
+	// Get counts for all types
+	const allTypes = POST_TYPES.map((t) => {
+		const typePosts = getPostsByType(allPosts, t);
+		return {
+			value: t,
+			label: capitalizeFirst(POST_TYPE_PLURALS[t]),
+			href: `/type/${POST_TYPE_PLURALS[t].toLowerCase()}/`,
+			count: typePosts.length,
+			icon: TYPE_ICONS[t] || '📌'
+		};
+	}).filter((t) => t.count > 0);
+
+	return {
+		type: singularType,
+		typeIcon: TYPE_ICONS[singularType] || '📌',
+		typePlural: POST_TYPE_PLURALS[singularType],
+		postsByDay: postsByDayArray,
+		totalPosts: posts.length,
+		allTypes
+	};
+};
+
+function capitalizeFirst(str: string): string {
+	return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/src/routes/type/[type]/+page.svelte
+++ b/src/routes/type/[type]/+page.svelte
@@ -8,12 +8,6 @@
 	function capitalizeFirst(str: string): string {
 		return str.charAt(0).toUpperCase() + str.slice(1);
 	}
-
-	const countDescription = $derived(
-		data.totalPosts === 1
-			? `1 ${data.type}`
-			: `${data.totalPosts} ${data.typePlural}`
-	);
 </script>
 
 <svelte:head>
@@ -30,7 +24,7 @@
 		current={capitalizeFirst(data.typePlural)}
 		currentIcon={data.typeIcon}
 		options={data.allTypes}
-		{countDescription}
+		count={data.totalPosts}
 	/>
 
 	<div class="posts-list h-feed">

--- a/src/routes/type/[type]/+page.svelte
+++ b/src/routes/type/[type]/+page.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import Nav from '$lib/components/Nav.svelte';
+	import { PostCard, DateHeader, DropdownArchiveHeader, PostsLayout } from '$lib/components/posts';
+
+	let { data }: { data: PageData } = $props();
+
+	function capitalizeFirst(str: string): string {
+		return str.charAt(0).toUpperCase() + str.slice(1);
+	}
+
+	const countDescription = $derived(
+		data.totalPosts === 1
+			? `1 ${data.type}`
+			: `${data.totalPosts} ${data.typePlural}`
+	);
+</script>
+
+<svelte:head>
+	<title>{capitalizeFirst(data.typePlural)} - Casey Gollan</title>
+	<meta name="description" content="{capitalizeFirst(data.typePlural)} by Casey Gollan" />
+	<meta property="og:title" content="{capitalizeFirst(data.typePlural)} - Casey Gollan" />
+	<meta property="og:type" content="website" />
+</svelte:head>
+
+<Nav currentPage="posts" />
+
+<PostsLayout>
+	<DropdownArchiveHeader
+		current={capitalizeFirst(data.typePlural)}
+		currentIcon={data.typeIcon}
+		options={data.allTypes}
+		{countDescription}
+	/>
+
+	<div class="posts-list h-feed">
+		{#each data.postsByDay as [dateKey, postsForDay] (dateKey)}
+			<DateHeader {dateKey} />
+
+			{#each postsForDay as post (post.slug)}
+				<PostCard {post} showType={false} />
+			{/each}
+		{/each}
+	</div>
+</PostsLayout>
+
+<style>
+	.posts-list {
+		line-height: 1.6;
+	}
+</style>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -15,6 +15,10 @@ const config = {
 				if (path.startsWith('/posts') || path === '/feed.xml' || path === '/index-accessible.html') {
 					return;
 				}
+				// Ignore trailing slash mismatches for date-based permalinks
+				if (referrer && path === referrer.replace(/\/$/, '')) {
+					return;
+				}
 				throw new Error(message);
 			}
 		}


### PR DESCRIPTION
## Summary
- Add type icons to post metadata (📝 note, 📄 article, 🔖 bookmark, 📷 photo, 🎬 video, 💬 reply, 🎵 media)
- Add 🔗 link icon to permalink/date display
- Add button-like hover states with rounded corners to all metadata links and back buttons
- Auto-link Mastodon handles (`@user@instance` → link to instance) and Bluesky handles
- Strip markdown syntax from article previews on index pages
- Create reusable post components (PostCard, PostMeta, PostContent, DateHeader, etc.)
- Add DropdownArchiveHeader with icons and pill-shaped count badges for type/tag archives
- Move Typekit font loading to app.html to reduce flash of unstyled content
- Split posts.ts into client-safe types (posts-types.ts) and server-only code
- Add `/type/[type]/` and `/tag/[tag]/` archive routes with dropdown navigation

## Test plan
- [ ] Verify posts page loads without FOUC
- [ ] Check hover states on metadata links show button styling
- [ ] Test type dropdown navigation on `/type/notes/`
- [ ] Verify Mastodon handles auto-link correctly (e.g., `@user@mas.to`)
- [ ] Check article previews strip markdown on index pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)