### PR TITLE
feat: add search functionality to library

### DIFF
--- a/src/routes/library/[[isbn]]/+page.svelte
+++ b/src/routes/library/[[isbn]]/+page.svelte
@@ -1059,7 +1059,9 @@
 
 			// Check for ISBN from route params and select that book
 			if (data.isbn) {
-				const bookNode = graphData.nodes.find(
+				// Use Graph.graphData() to get nodes with __threeObj attached
+				const currentNodes = Graph.graphData().nodes;
+				const bookNode = currentNodes.find(
 					(n: Node) => n.group === 'book' && n.isbn === data.isbn
 				);
 				if (bookNode) {


### PR DESCRIPTION
Add a search button (🔍) near the mode toggle that expands into a text
field when clicked. Typing filters visible book nodes in real-time by
matching against book titles (case-insensitive). Press Escape to close
search and restore all books to view.