### PR TITLE
fix: add missing indieauth-metadata link for proper discovery

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,6 +7,13 @@
 
 <svelte:head>
 	<link rel="icon" href={favicon} />
+	<!-- IndieAuth -->
+	<link rel="authorization_endpoint" href="https://kit.caseyagollan.com/auth" />
+	<link rel="token_endpoint" href="https://kit.caseyagollan.com/auth/token" />
+	<link rel="indieauth-metadata" href="https://kit.caseyagollan.com/.well-known/oauth-authorization-server" />
+	<link rel="micropub" href="https://kit.caseyagollan.com/micropub" />
+	<link rel="me" href="https://social.coop/@caseyg" />
+	<!-- Webmention -->
 	<link rel="webmention" href="https://webmention.io/caseyagollan.com/webmention" />
 	<link rel="pingback" href="https://webmention.io/caseyagollan.com/xmlrpc" />
 </svelte:head>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -508,16 +508,6 @@
         href="https://unpkg.com/telescopic-text@1.2.4/lib/index.css"
         rel="stylesheet"
     />
-    <link rel="micropub" href="https://kit.caseyagollan.com/micropub" />
-    <link
-        rel="authorization_endpoint"
-        href="https://kit.caseyagollan.com/auth"
-    />
-    <link rel="token_endpoint" href="https://kit.caseyagollan.com/auth/token" />
-    <link
-        rel="webmention"
-        href="https://webmention.io/caseyagollan.com/webmention"
-    />
     <link rel="feed" href="/posts/" type="text/html" title="All Posts" />
     <link
         rel="alternate"
@@ -670,9 +660,6 @@
     class="sisu-image"
 />
 
-<a rel="me" href="https://social.coop/@caseyg" class="hidden"
-    >@caseyg@social.coop</a
->
 
 <style>
     /* ==========================================
@@ -864,10 +851,6 @@
         margin: var(--spacing-lg) auto;
         padding: 0 var(--spacing-md);
         display: block;
-    }
-
-    .hidden {
-        display: none;
     }
 
     /* ==========================================


### PR DESCRIPTION
- Add indieauth-metadata link pointing to /.well-known/oauth-authorization-server
- Move all IndieAuth links (authorization_endpoint, token_endpoint, micropub) to layout
- Add rel="me" as <link> in head (previously hidden anchor in body)
- Remove duplicate webmention link from page (already in layout)
- Clean up unused .hidden CSS class