### PR TITLE
fix: render photo and video media from frontmatter

### DIFF
--- a/src/lib/components/posts/PostCard.svelte
+++ b/src/lib/components/posts/PostCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import PostMeta from './PostMeta.svelte';
 	import PostContent from './PostContent.svelte';
+	import PostMedia from './PostMedia.svelte';
 	import type { Post } from '$lib/posts-types';
 	import { getPostPermalink } from '$lib/posts-types';
 
@@ -62,6 +63,7 @@
 		</p>
 		<a href={permalink} class="read-more">Read more</a>
 	{:else}
+		<PostMedia photos={post.photo} videos={post.video} />
 		<PostContent content={post.content} />
 	{/if}
 </article>

--- a/src/lib/components/posts/PostMedia.svelte
+++ b/src/lib/components/posts/PostMedia.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import type { MediaItem } from '$lib/posts-types';
+
+	interface Props {
+		photos?: MediaItem[];
+		videos?: MediaItem[];
+	}
+
+	let { photos, videos }: Props = $props();
+</script>
+
+{#if photos && photos.length > 0}
+	<div class="photo-content">
+		{#each photos as img (img.url)}
+			<figure>
+				<img src={img.url} alt={img.alt ?? 'Photo'} class="u-photo" loading="lazy" />
+				{#if img.alt}
+					<figcaption>{img.alt}</figcaption>
+				{/if}
+			</figure>
+		{/each}
+	</div>
+{/if}
+
+{#if videos && videos.length > 0}
+	<div class="video-content">
+		{#each videos as vid (vid.url)}
+			<figure>
+				<!-- svelte-ignore a11y_media_has_caption -->
+				<video controls class="u-video" preload="metadata">
+					<source src={vid.url} type={vid.type ?? 'video/mp4'} />
+				</video>
+				{#if vid.alt}
+					<figcaption>{vid.alt}</figcaption>
+				{/if}
+			</figure>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.photo-content,
+	.video-content {
+		margin: 0.5rem 0;
+	}
+
+	figure {
+		margin: 0 0 1rem;
+	}
+
+	figure:last-child {
+		margin-bottom: 0;
+	}
+
+	.u-photo,
+	.u-video {
+		display: block;
+		max-width: 100%;
+		height: auto;
+		border-radius: 4px;
+	}
+
+	figcaption {
+		margin-top: 0.5rem;
+		font-size: 0.875rem;
+		color: rgba(255, 255, 255, 0.7);
+		line-height: 1.4;
+	}
+</style>

--- a/src/lib/components/posts/index.ts
+++ b/src/lib/components/posts/index.ts
@@ -1,6 +1,7 @@
 export { default as PostCard } from './PostCard.svelte';
 export { default as PostMeta } from './PostMeta.svelte';
 export { default as PostContent } from './PostContent.svelte';
+export { default as PostMedia } from './PostMedia.svelte';
 export { default as PostCategories } from './PostCategories.svelte';
 export { default as DateHeader } from './DateHeader.svelte';
 export { default as ArchiveHeader } from './ArchiveHeader.svelte';

--- a/src/lib/posts-types.ts
+++ b/src/lib/posts-types.ts
@@ -1,5 +1,11 @@
 // Client-safe post types and constants (no Node.js imports)
 
+export interface MediaItem {
+	url: string;
+	alt?: string;
+	type?: string;
+}
+
 export interface Post {
 	slug: string;
 	type: 'note' | 'article' | 'bookmark' | 'photo' | 'video' | 'reply' | 'media';
@@ -10,6 +16,8 @@ export interface Post {
 	content: string;
 	visibility?: string;
 	syndication?: string[];
+	photo?: MediaItem[];
+	video?: MediaItem[];
 	filePath: string;
 }
 

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -5,9 +5,44 @@ import { readdir, readFile } from 'fs/promises';
 import { join } from 'path';
 import matter from 'gray-matter';
 
+import type { Post, MediaItem } from './posts-types';
+
 // Re-export client-safe types and functions
-export type { Post } from './posts-types';
+export type { Post, MediaItem } from './posts-types';
 export { POST_TYPES, POST_TYPE_PLURALS, getPostPermalink, getPostsByDay } from './posts-types';
+
+function normalizeMedia(
+	value: unknown,
+	altFallbacks?: unknown
+): MediaItem[] | undefined {
+	if (!value) return undefined;
+	const items = Array.isArray(value) ? value : [value];
+	const altList = Array.isArray(altFallbacks) ? altFallbacks : [];
+
+	const normalized = items
+		.map((item, i): MediaItem | null => {
+			if (typeof item === 'string') {
+				return { url: item, alt: typeof altList[i] === 'string' ? altList[i] : undefined };
+			}
+			if (item && typeof item === 'object' && typeof (item as any).url === 'string') {
+				const m = item as Record<string, unknown>;
+				return {
+					url: m.url as string,
+					alt:
+						typeof m.alt === 'string'
+							? m.alt
+							: typeof altList[i] === 'string'
+								? (altList[i] as string)
+								: undefined,
+					type: typeof m.type === 'string' ? m.type : undefined
+				};
+			}
+			return null;
+		})
+		.filter((m): m is MediaItem => m !== null);
+
+	return normalized.length > 0 ? normalized : undefined;
+}
 
 // Mapping from plural folder names to singular type names
 const PLURAL_TO_SINGULAR: Record<string, string> = {
@@ -19,8 +54,6 @@ const PLURAL_TO_SINGULAR: Record<string, string> = {
 	replies: 'reply',
 	media: 'media'
 };
-
-import type { Post } from './posts-types';
 
 export async function getAllPosts(): Promise<Post[]> {
 	const contentDir = join(process.cwd(), 'content');
@@ -62,6 +95,8 @@ export async function getAllPosts(): Promise<Post[]> {
 					content,
 					visibility: data.visibility,
 					syndication: data.syndication,
+					photo: normalizeMedia(data.photo, data['mp-photo-alt']),
+					video: normalizeMedia(data.video),
 					filePath: `${type}/${file}`
 				});
 			}

--- a/src/routes/[year]/[month]/[day]/[slug]/+page.svelte
+++ b/src/routes/[year]/[month]/[day]/[slug]/+page.svelte
@@ -2,7 +2,7 @@
 	import type { PageData } from './$types';
 	import Nav from '$lib/components/Nav.svelte';
 	import Webmentions from '$lib/components/Webmentions.svelte';
-	import { PostsLayout, DateArchiveHeader, PostMeta, PostContent } from '$lib/components/posts';
+	import { PostsLayout, DateArchiveHeader, PostMeta, PostContent, PostMedia } from '$lib/components/posts';
 
 	let { data }: { data: PageData } = $props();
 
@@ -36,6 +36,7 @@
 			<h1 class="p-name post-title">{data.post.title}</h1>
 		{/if}
 
+		<PostMedia photos={data.post.photo} videos={data.post.video} />
 		<PostContent content={data.post.content} />
 
 		<Webmentions url={permalink} />


### PR DESCRIPTION
## Why images weren't loading

Photo posts (and video posts) store their media in frontmatter:

```yaml
photo:
  - url: https://files.caseyagollan.com/media/photos/2026/05/05/img-3970.jpg
    alt: ...
```

But the loader in `src/lib/posts.ts` never extracted `data.photo` (or `data.video`) into the `Post` object, and `PostCard.svelte` / the single-post page (`[year]/[month]/[day]/[slug]/+page.svelte`) only rendered the markdown body via `PostContent`. For a photo post the body is empty, so nothing showed up — neither in the posts feed nor on the single-post page.

The legacy Eleventy templates (`archive/_includes/post-display.njk`) had a `{% for img in post.data.photo %}…<img class="u-photo">` block that was never ported during the SvelteKit migration.

## Changes

- Add `photo?: MediaItem[]` and `video?: MediaItem[]` to the `Post` type (`src/lib/posts-types.ts`).
- Extract and normalize them in `getAllPosts` (`src/lib/posts.ts`), supporting both `[{url, alt}, …]` and bare-string forms, plus `mp-photo-alt` fallback.
- New `PostMedia.svelte` component renders `<figure><img class="u-photo"></figure>` for photos and `<video class="u-video">` for videos, matching the legacy IndieWeb classes.
- Wire `PostMedia` into `PostCard.svelte` and the single-post page, above the markdown content.

## Verified locally

- `/posts/` — photo `<img class="u-photo">` renders for the quokkas post.
- `/2026/05/04/54f22/` — single photo post renders the new "Addiction by Design" page image with caption.
- `/2025/10/12/sora-cloud-punch/` — single video post renders `<video><source src=…></video>`.
- `bun run build` succeeds.


---
_Generated by [Claude Code](https://claude.ai/code/session_018RUcsJhygY2jQsX9etHQqr)_